### PR TITLE
feat: new rule `enforce consistent variable syntax`

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 | [no-unregistered-classes](docs/rules/no-unregistered-classes.md) | Report classes not registered with tailwindcss. | ✔ | ✔ | ✔ |  |
 | [no-conflicting-classes](docs/rules/no-conflicting-classes.md) | Report classes that produce conflicting styles. |  | ✔ |  |  |
 | [no-restricted-classes](docs/rules/no-restricted-classes.md) | Disallow restricted classes. | ✔ | ✔ |  |  |
+| [enforce-consistent-variable-syntax](docs/rules/enforce-consistent-variable-syntax.md) | Enforce consistent variable syntax. | ✔ | ✔ |  | ✔ |
 
 <br/>
 <br/>

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 | [no-unnecessary-whitespace](docs/rules/no-unnecessary-whitespace.md) | Disallow unnecessary whitespace in tailwind classes. | ✔ | ✔ | ✔ | ✔ |
 | [sort-classes](docs/rules/sort-classes.md) | Enforce a consistent order for tailwind classes. | ✔ | ✔ | ✔ | ✔ |
 | [no-duplicate-classes](docs/rules/no-duplicate-classes.md) | Remove duplicate classes. | ✔ | ✔ | ✔ | ✔ |
+| [enforce-consistent-variable-syntax](docs/rules/enforce-consistent-variable-syntax.md) | Enforce consistent variable syntax. | ✔ | ✔ |  | ✔ |
 
 #### Correctness rules
 
@@ -194,7 +195,6 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 | [no-unregistered-classes](docs/rules/no-unregistered-classes.md) | Report classes not registered with tailwindcss. | ✔ | ✔ | ✔ |  |
 | [no-conflicting-classes](docs/rules/no-conflicting-classes.md) | Report classes that produce conflicting styles. |  | ✔ |  |  |
 | [no-restricted-classes](docs/rules/no-restricted-classes.md) | Disallow restricted classes. | ✔ | ✔ |  |  |
-| [enforce-consistent-variable-syntax](docs/rules/enforce-consistent-variable-syntax.md) | Enforce consistent variable syntax. | ✔ | ✔ |  | ✔ |
 
 <br/>
 <br/>

--- a/docs/rules/enforce-consistent-variable-syntax.md
+++ b/docs/rules/enforce-consistent-variable-syntax.md
@@ -1,0 +1,74 @@
+# better-tailwindcss/enforce-consistent-variable-syntax
+
+Enforce consistent css variable syntax in tailwindcss class strings.
+
+<br/>
+
+## Options
+
+### `syntax`
+
+  The syntax to enforce for css variables in tailwindcss class strings.
+
+  **Type**: `"arbitrary"` | `"parentheses"`  
+  **Default**: `"parentheses"`
+
+### `attributes`
+
+  The name of the attribute that contains the tailwind classes. This can also be set globally via the [`settings` object](../settings/settings.md#attributes).  
+
+  **Type**: Array of [Matchers](../configuration/advanced.md)  
+  **Default**: [Name](../configuration/advanced.md#name-based-matching) for `"class"` and [strings Matcher](../configuration/advanced.md#types-of-matchers) for `"class", "className"`
+
+<br/>
+
+### `callees`
+
+  List of function names which arguments should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md#callees).  
+  
+  **Type**: Array of [Matchers](../configuration/advanced.md)  
+  **Default**: [Matchers](../configuration/advanced.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
+
+<br/>
+
+### `variables`
+
+  List of variable names whose initializer should also get linted. This can also be set globally via the [`settings` object](../settings/settings.md#variables).  
+  
+  **Type**: Array of [Matchers](../configuration/advanced.md)  
+  **Default**:  [strings Matcher](../configuration/advanced.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
+
+<br/>
+
+### `tags`
+
+  List of template literal tag names whose content should get linted. This can also be set globally via the [`settings` object](../settings/settings.md#tags).  
+  
+  **Type**: Array of [Matchers](../configuration/advanced.md)  
+  **Default**: None
+
+  Note: When using the `tags` option, it is recommended to use the [strings Matcher](../configuration/advanced.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
+
+<br/>
+
+## Examples
+
+```tsx
+// ❌ BAD: Incorrect css variable syntax with option `syntax: "parentheses"`
+<div class="bg-[var(--primary)]" />;
+```
+
+```tsx
+// ✅ GOOD: With option `syntax: "parentheses"`
+<div class="bg-(--primary)" />;
+```
+
+```tsx
+// ❌ BAD: Incorrect css variable syntax with option `syntax: "arbitrary"`
+<div class="bg-(--primary)" />;
+```
+
+```tsx
+// ✅ GOOD: With option `syntax: "arbitrary"`
+<div class="bg-[var(--primary)]" />;
+```

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -1,3 +1,4 @@
+import { enforceConsistentVariableSyntax } from "better-tailwindcss:rules:enforce-consistent-variable-syntax.js";
 import { multiline } from "better-tailwindcss:rules:multiline.js";
 import { noConflictingClasses } from "better-tailwindcss:rules:no-conflicting-classes.js";
 import { noDuplicateClasses } from "better-tailwindcss:rules:no-duplicate-classes.js";
@@ -14,6 +15,7 @@ const plugin = {
     name: "better-tailwindcss"
   },
   rules: {
+    [enforceConsistentVariableSyntax.name]: enforceConsistentVariableSyntax.rule,
     [multiline.name]: multiline.rule,
     [noConflictingClasses.name]: noConflictingClasses.rule,
     [noDuplicateClasses.name]: noDuplicateClasses.rule,

--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -72,6 +72,31 @@ describe(enforceConsistentVariableSyntax.name, () => {
     );
   });
 
+  it("should work when surrounded by underlines in arbitrary syntax", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="bg-[__var(--brand)__]" />`,
+            angularOutput: `<img class="bg-(--brand)" />`,
+            errors: 1,
+            html: `<img class="bg-[__var(--brand)__]" />`,
+            htmlOutput: `<img class="bg-(--brand)" />`,
+            jsx: `() => <img class="bg-[__var(--brand)__]" />`,
+            jsxOutput: `() => <img class="bg-(--brand)" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="bg-[__var(--brand)__]" />`,
+            svelteOutput: `<img class="bg-(--brand)" />`,
+            vue: `<template><img class="bg-[__var(--brand)__]" /></template>`,
+            vueOutput: `<template><img class="bg-(--brand)" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
   it("should preserve fallback values", () => {
     lint(
       enforceConsistentVariableSyntax,

--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -310,32 +310,32 @@ describe(enforceConsistentVariableSyntax.name, () => {
       {
         invalid: [
           {
-            angular: `<img class="${multilineParentheses}"} />`,
-            angularOutput: `<img class="${multilineArbitrary}"} />`,
+            angular: `<img class="${multilineParentheses}" />`,
+            angularOutput: `<img class="${multilineArbitrary}" />`,
             errors: 2,
-            html: `<img class="${multilineParentheses}"} />`,
-            htmlOutput: `<img class="${multilineArbitrary}"} />`,
+            html: `<img class="${multilineParentheses}" />`,
+            htmlOutput: `<img class="${multilineArbitrary}" />`,
             jsx: `() => <img class={\`${multilineParentheses}\`} />`,
             jsxOutput: `() => <img class={\`${multilineArbitrary}\`} />`,
             options: [{ syntax: "arbitrary" }],
-            svelte: `<img class="${multilineParentheses}"} />`,
-            svelteOutput: `<img class="${multilineArbitrary}"} />`,
-            vue: `<template><img class="${multilineParentheses}"} /></template>`,
-            vueOutput: `<template><img class="${multilineArbitrary}"} /></template>`
+            svelte: `<img class="${multilineParentheses}" />`,
+            svelteOutput: `<img class="${multilineArbitrary}" />`,
+            vue: `<template><img class="${multilineParentheses}" /></template>`,
+            vueOutput: `<template><img class="${multilineArbitrary}" /></template>`
           },
           {
-            angular: `<img class="${multilineArbitrary}"} />`,
-            angularOutput: `<img class="${multilineParentheses}"} />`,
+            angular: `<img class="${multilineArbitrary}" />`,
+            angularOutput: `<img class="${multilineParentheses}" />`,
             errors: 2,
-            html: `<img class="${multilineArbitrary}"} />`,
-            htmlOutput: `<img class="${multilineParentheses}"} />`,
+            html: `<img class="${multilineArbitrary}" />`,
+            htmlOutput: `<img class="${multilineParentheses}" />`,
             jsx: `() => <img class={\`${multilineArbitrary}\`} />`,
             jsxOutput: `() => <img class={\`${multilineParentheses}\`} />`,
             options: [{ syntax: "parentheses" }],
-            svelte: `<img class="${multilineArbitrary}"} />`,
-            svelteOutput: `<img class="${multilineParentheses}"} />`,
-            vue: `<template><img class="${multilineArbitrary}"} /></template>`,
-            vueOutput: `<template><img class="${multilineParentheses}"} /></template>`
+            svelte: `<img class="${multilineArbitrary}" />`,
+            svelteOutput: `<img class="${multilineParentheses}" />`,
+            vue: `<template><img class="${multilineArbitrary}" /></template>`,
+            vueOutput: `<template><img class="${multilineParentheses}" /></template>`
           }
         ]
       }

--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -1,0 +1,269 @@
+import { describe, it } from "vitest";
+
+import { enforceConsistentVariableSyntax } from "better-tailwindcss:rules:enforce-consistent-variable-syntax.js";
+import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests:utils.js";
+
+
+describe(enforceConsistentVariableSyntax.name, () => {
+
+  it("should not report on the preferred syntax", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="bg-(--brand)" />`,
+            html: `<img class="bg-(--brand)" />`,
+            jsx: `() => <img class="bg-(--brand)" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="bg-(--brand)" />`,
+            vue: `<template><img class="bg-(--brand)" /></template>`
+          },
+          {
+            angular: `<img class="bg-[var(--brand)]" />`,
+            html: `<img class="bg-[var(--brand)]" />`,
+            jsx: `() => <img class="bg-[var(--brand)]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="bg-[var(--brand)]" />`,
+            vue: `<template><img class="bg-[var(--brand)]" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should report on the wrong syntax", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="bg-(--brand)" />`,
+            angularOutput: `<img class="bg-[var(--brand)]" />`,
+            errors: 1,
+            html: `<img class="bg-(--brand)" />`,
+            htmlOutput: `<img class="bg-[var(--brand)]" />`,
+            jsx: `() => <img class="bg-(--brand)" />`,
+            jsxOutput: `() => <img class="bg-[var(--brand)]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="bg-(--brand)" />`,
+            svelteOutput: `<img class="bg-[var(--brand)]" />`,
+            vue: `<template><img class="bg-(--brand)" /></template>`,
+            vueOutput: `<template><img class="bg-[var(--brand)]" /></template>`
+          },
+          {
+            angular: `<img class="bg-[var(--brand)]" />`,
+            angularOutput: `<img class="bg-(--brand)" />`,
+            errors: 1,
+            html: `<img class="bg-[var(--brand)]" />`,
+            htmlOutput: `<img class="bg-(--brand)" />`,
+            jsx: `() => <img class="bg-[var(--brand)]" />`,
+            jsxOutput: `() => <img class="bg-(--brand)" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="bg-[var(--brand)]" />`,
+            svelteOutput: `<img class="bg-(--brand)" />`,
+            vue: `<template><img class="bg-[var(--brand)]" /></template>`,
+            vueOutput: `<template><img class="bg-(--brand)" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should preserve fallback values", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="bg-[var(--brand,_#000)]" />`,
+            angularOutput: `<img class="bg-(--brand,_#000)" />`,
+            errors: 1,
+            html: `<img class="bg-[var(--brand,_#000)]" />`,
+            htmlOutput: `<img class="bg-(--brand,_#000)" />`,
+            jsx: `() => <img class="bg-[var(--brand,_#000)]" />`,
+            jsxOutput: `() => <img class="bg-(--brand,_#000)" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="bg-[var(--brand,_#000)]" />`,
+            svelteOutput: `<img class="bg-(--brand,_#000)" />`,
+            vue: `<template><img class="bg-[var(--brand,_#000)]" /></template>`,
+            vueOutput: `<template><img class="bg-(--brand,_#000)" /></template>`
+          },
+          {
+            angular: `<img class="bg-(--brand,_#000)" />`,
+            angularOutput: `<img class="bg-[var(--brand,_#000)]" />`,
+            errors: 1,
+            html: `<img class="bg-(--brand,_#000)" />`,
+            htmlOutput: `<img class="bg-[var(--brand,_#000)]" />`,
+            jsx: `() => <img class="bg-(--brand,_#000)" />`,
+            jsxOutput: `() => <img class="bg-[var(--brand,_#000)]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="bg-(--brand,_#000)" />`,
+            svelteOutput: `<img class="bg-[var(--brand,_#000)]" />`,
+            vue: `<template><img class="bg-(--brand,_#000)" /></template>`,
+            vueOutput: `<template><img class="bg-[var(--brand,_#000)]" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should preserve css functions", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="height-[var(--header,calc(100%_-_1rem))]" />`,
+            angularOutput: `<img class="height-(--header,calc(100%_-_1rem))" />`,
+            errors: 1,
+            html: `<img class="height-[var(--header,calc(100%_-_1rem))]" />`,
+            htmlOutput: `<img class="height-(--header,calc(100%_-_1rem))" />`,
+            jsx: `() => <img class="height-[var(--header,calc(100%_-_1rem))]" />`,
+            jsxOutput: `() => <img class="height-(--header,calc(100%_-_1rem))" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="height-[var(--header,calc(100%_-_1rem))]" />`,
+            svelteOutput: `<img class="height-(--header,calc(100%_-_1rem))" />`,
+            vue: `<template><img class="height-[var(--header,calc(100%_-_1rem))]" /></template>`,
+            vueOutput: `<template><img class="height-(--header,calc(100%_-_1rem))" /></template>`
+          },
+          {
+            angular: `<img class="height-(--header,calc(100%_-_1rem))" />`,
+            angularOutput: `<img class="height-[var(--header,calc(100%_-_1rem))]" />`,
+            errors: 1,
+            html: `<img class="height-(--header,calc(100%_-_1rem))" />`,
+            htmlOutput: `<img class="height-[var(--header,calc(100%_-_1rem))]" />`,
+            jsx: `() => <img class="height-(--header,calc(100%_-_1rem))" />`,
+            jsxOutput: `() => <img class="height-[var(--header,calc(100%_-_1rem))]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="height-(--header,calc(100%_-_1rem))" />`,
+            svelteOutput: `<img class="height-[var(--header,calc(100%_-_1rem))]" />`,
+            vue: `<template><img class="height-(--header,calc(100%_-_1rem))" /></template>`,
+            vueOutput: `<template><img class="height-[var(--header,calc(100%_-_1rem))]" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should work with nested variables", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="bg-[var(--brand,var(--secondary))]" />`,
+            angularOutput: `<img class="bg-(--brand,var(--secondary))" />`,
+            errors: 1,
+            html: `<img class="bg-[var(--brand,var(--secondary))]" />`,
+            htmlOutput: `<img class="bg-(--brand,var(--secondary))" />`,
+            jsx: `() => <img class="bg-[var(--brand,var(--secondary))]" />`,
+            jsxOutput: `() => <img class="bg-(--brand,var(--secondary))" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="bg-[var(--brand,var(--secondary))]" />`,
+            svelteOutput: `<img class="bg-(--brand,var(--secondary))" />`,
+            vue: `<template><img class="bg-[var(--brand,var(--secondary))]" /></template>`,
+            vueOutput: `<template><img class="bg-(--brand,var(--secondary))" /></template>`
+          },
+          {
+            angular: `<img class="bg-(--brand,var(--secondary))" />`,
+            angularOutput: `<img class="bg-[var(--brand,var(--secondary))]" />`,
+            errors: 1,
+            html: `<img class="bg-(--brand,var(--secondary))" />`,
+            htmlOutput: `<img class="bg-[var(--brand,var(--secondary))]" />`,
+            jsx: `() => <img class="bg-(--brand,var(--secondary))" />`,
+            jsxOutput: `() => <img class="bg-[var(--brand,var(--secondary))]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="bg-(--brand,var(--secondary))" />`,
+            svelteOutput: `<img class="bg-[var(--brand,var(--secondary))]" />`,
+            vue: `<template><img class="bg-(--brand,var(--secondary))" /></template>`,
+            vueOutput: `<template><img class="bg-[var(--brand,var(--secondary))]" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should preserve the case sensitivity of the variable name", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="bg-(--Brand)" />`,
+            angularOutput: `<img class="bg-[var(--Brand)]" />`,
+            errors: 1,
+            html: `<img class="bg-(--Brand)" />`,
+            htmlOutput: `<img class="bg-[var(--Brand)]" />`,
+            jsx: `() => <img class="bg-(--Brand)" />`,
+            jsxOutput: `() => <img class="bg-[var(--Brand)]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="bg-(--Brand)" />`,
+            svelteOutput: `<img class="bg-[var(--Brand)]" />`,
+            vue: `<template><img class="bg-(--Brand)" /></template>`,
+            vueOutput: `<template><img class="bg-[var(--Brand)]" /></template>`
+          },
+          {
+            angular: `<img class="bg-[var(--Brand)]" />`,
+            angularOutput: `<img class="bg-(--Brand)" />`,
+            errors: 1,
+            html: `<img class="bg-[var(--Brand)]" />`,
+            htmlOutput: `<img class="bg-(--Brand)" />`,
+            jsx: `() => <img class="bg-[var(--Brand)]" />`,
+            jsxOutput: `() => <img class="bg-(--Brand)" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="bg-[var(--Brand)]" />`,
+            svelteOutput: `<img class="bg-(--Brand)" />`,
+            vue: `<template><img class="bg-[var(--Brand)]" /></template>`,
+            vueOutput: `<template><img class="bg-(--Brand)" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should preserve allow special characters in variable names", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="bg-(--special_variable_😏)" />`,
+            angularOutput: `<img class="bg-[var(--special_variable_😏)]" />`,
+            errors: 1,
+            html: `<img class="bg-(--special_variable_😏)" />`,
+            htmlOutput: `<img class="bg-[var(--special_variable_😏)]" />`,
+            jsx: `() => <img class="bg-(--special_variable_😏)" />`,
+            jsxOutput: `() => <img class="bg-[var(--special_variable_😏)]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="bg-(--special_variable_😏)" />`,
+            svelteOutput: `<img class="bg-[var(--special_variable_😏)]" />`,
+            vue: `<template><img class="bg-(--special_variable_😏)" /></template>`,
+            vueOutput: `<template><img class="bg-[var(--special_variable_😏)]" /></template>`
+          },
+          {
+            angular: `<img class="bg-[var(--special_variable_😏)]" />`,
+            angularOutput: `<img class="bg-(--special_variable_😏)" />`,
+            errors: 1,
+            html: `<img class="bg-[var(--special_variable_😏)]" />`,
+            htmlOutput: `<img class="bg-(--special_variable_😏)" />`,
+            jsx: `() => <img class="bg-[var(--special_variable_😏)]" />`,
+            jsxOutput: `() => <img class="bg-(--special_variable_😏)" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="bg-[var(--special_variable_😏)]" />`,
+            svelteOutput: `<img class="bg-(--special_variable_😏)" />`,
+            vue: `<template><img class="bg-[var(--special_variable_😏)]" /></template>`,
+            vueOutput: `<template><img class="bg-(--special_variable_😏)" /></template>`
+          }
+        ]
+      }
+    );
+  });
+});

--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -175,6 +175,45 @@ describe(enforceConsistentVariableSyntax.name, () => {
     );
   });
 
+  it("should work with the important modifier", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="bg-(--brand)!" />`,
+            angularOutput: `<img class="bg-[var(--brand)]!" />`,
+            errors: 1,
+            html: `<img class="bg-(--brand)!" />`,
+            htmlOutput: `<img class="bg-[var(--brand)]!" />`,
+            jsx: `() => <img class="bg-(--brand)!" />`,
+            jsxOutput: `() => <img class="bg-[var(--brand)]!" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="bg-(--brand)!" />`,
+            svelteOutput: `<img class="bg-[var(--brand)]!" />`,
+            vue: `<template><img class="bg-(--brand)!" /></template>`,
+            vueOutput: `<template><img class="bg-[var(--brand)]!" /></template>`
+          },
+          {
+            angular: `<img class="bg-[var(--brand)]!" />`,
+            angularOutput: `<img class="bg-(--brand)!" />`,
+            errors: 1,
+            html: `<img class="bg-[var(--brand)]!" />`,
+            htmlOutput: `<img class="bg-(--brand)!" />`,
+            jsx: `() => <img class="bg-[var(--brand)]!" />`,
+            jsxOutput: `() => <img class="bg-(--brand)!" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="bg-[var(--brand)]!" />`,
+            svelteOutput: `<img class="bg-(--brand)!" />`,
+            vue: `<template><img class="bg-[var(--brand)]!" /></template>`,
+            vueOutput: `<template><img class="bg-(--brand)!" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
   it("should preserve fallback values", () => {
     lint(
       enforceConsistentVariableSyntax,

--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -97,6 +97,84 @@ describe(enforceConsistentVariableSyntax.name, () => {
     );
   });
 
+  it("should work with variants", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="hover:bg-(--brand)" />`,
+            angularOutput: `<img class="hover:bg-[var(--brand)]" />`,
+            errors: 1,
+            html: `<img class="hover:bg-(--brand)" />`,
+            htmlOutput: `<img class="hover:bg-[var(--brand)]" />`,
+            jsx: `() => <img class="hover:bg-(--brand)" />`,
+            jsxOutput: `() => <img class="hover:bg-[var(--brand)]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="hover:bg-(--brand)" />`,
+            svelteOutput: `<img class="hover:bg-[var(--brand)]" />`,
+            vue: `<template><img class="hover:bg-(--brand)" /></template>`,
+            vueOutput: `<template><img class="hover:bg-[var(--brand)]" /></template>`
+          },
+          {
+            angular: `<img class="hover:bg-[var(--brand)]" />`,
+            angularOutput: `<img class="hover:bg-(--brand)" />`,
+            errors: 1,
+            html: `<img class="hover:bg-[var(--brand)]" />`,
+            htmlOutput: `<img class="hover:bg-(--brand)" />`,
+            jsx: `() => <img class="hover:bg-[var(--brand)]" />`,
+            jsxOutput: `() => <img class="hover:bg-(--brand)" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="hover:bg-[var(--brand)]" />`,
+            svelteOutput: `<img class="hover:bg-(--brand)" />`,
+            vue: `<template><img class="hover:bg-[var(--brand)]" /></template>`,
+            vueOutput: `<template><img class="hover:bg-(--brand)" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should work with other classes", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="text-red-500 bg-(--brand)" />`,
+            angularOutput: `<img class="text-red-500 bg-[var(--brand)]" />`,
+            errors: 1,
+            html: `<img class="text-red-500 bg-(--brand)" />`,
+            htmlOutput: `<img class="text-red-500 bg-[var(--brand)]" />`,
+            jsx: `() => <img class="text-red-500 bg-(--brand)" />`,
+            jsxOutput: `() => <img class="text-red-500 bg-[var(--brand)]" />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="text-red-500 bg-(--brand)" />`,
+            svelteOutput: `<img class="text-red-500 bg-[var(--brand)]" />`,
+            vue: `<template><img class="text-red-500 bg-(--brand)" /></template>`,
+            vueOutput: `<template><img class="text-red-500 bg-[var(--brand)]" /></template>`
+          },
+          {
+            angular: `<img class="text-red-500 bg-[var(--brand)]" />`,
+            angularOutput: `<img class="text-red-500 bg-(--brand)" />`,
+            errors: 1,
+            html: `<img class="text-red-500 bg-[var(--brand)]" />`,
+            htmlOutput: `<img class="text-red-500 bg-(--brand)" />`,
+            jsx: `() => <img class="text-red-500 bg-[var(--brand)]" />`,
+            jsxOutput: `() => <img class="text-red-500 bg-(--brand)" />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="text-red-500 bg-[var(--brand)]" />`,
+            svelteOutput: `<img class="text-red-500 bg-(--brand)" />`,
+            vue: `<template><img class="text-red-500 bg-[var(--brand)]" /></template>`,
+            vueOutput: `<template><img class="text-red-500 bg-(--brand)" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
   it("should preserve fallback values", () => {
     lint(
       enforceConsistentVariableSyntax,

--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "vitest";
 
 import { enforceConsistentVariableSyntax } from "better-tailwindcss:rules:enforce-consistent-variable-syntax.js";
-import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests:utils.js";
+import { createTrimTag, lint, TEST_SYNTAXES } from "better-tailwindcss:tests:utils.js";
 
 
 describe(enforceConsistentVariableSyntax.name, () => {
@@ -286,6 +286,56 @@ describe(enforceConsistentVariableSyntax.name, () => {
             svelteOutput: `<img class="bg-(--special_variable_😏)" />`,
             vue: `<template><img class="bg-[var(--special_variable_😏)]" /></template>`,
             vueOutput: `<template><img class="bg-(--special_variable_😏)" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should work with multiline classes", () => {
+    const trim = createTrimTag(4);
+
+    const multilineParentheses = trim`
+      bg-(--primary)
+      hover:bg-(--secondary)
+    `;
+    const multilineArbitrary = trim`
+      bg-[var(--primary)]
+      hover:bg-[var(--secondary)]
+    `;
+
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="${multilineParentheses}"} />`,
+            angularOutput: `<img class="${multilineArbitrary}"} />`,
+            errors: 2,
+            html: `<img class="${multilineParentheses}"} />`,
+            htmlOutput: `<img class="${multilineArbitrary}"} />`,
+            jsx: `() => <img class={\`${multilineParentheses}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineArbitrary}\`} />`,
+            options: [{ syntax: "arbitrary" }],
+            svelte: `<img class="${multilineParentheses}"} />`,
+            svelteOutput: `<img class="${multilineArbitrary}"} />`,
+            vue: `<template><img class="${multilineParentheses}"} /></template>`,
+            vueOutput: `<template><img class="${multilineArbitrary}"} /></template>`
+          },
+          {
+            angular: `<img class="${multilineArbitrary}"} />`,
+            angularOutput: `<img class="${multilineParentheses}"} />`,
+            errors: 2,
+            html: `<img class="${multilineArbitrary}"} />`,
+            htmlOutput: `<img class="${multilineParentheses}"} />`,
+            jsx: `() => <img class={\`${multilineArbitrary}\`} />`,
+            jsxOutput: `() => <img class={\`${multilineParentheses}\`} />`,
+            options: [{ syntax: "parentheses" }],
+            svelte: `<img class="${multilineArbitrary}"} />`,
+            svelteOutput: `<img class="${multilineParentheses}"} />`,
+            vue: `<template><img class="${multilineArbitrary}"} /></template>`,
+            vueOutput: `<template><img class="${multilineParentheses}"} /></template>`
           }
         ]
       }

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -94,16 +94,17 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
     const { syntax } = getOptions(ctx);
 
     const classChunks = splitClasses(literal.content);
-    const whiteSpaceChunks = splitWhitespaces(literal.content);
+    const whitespaceChunks = splitWhitespaces(literal.content);
+
+    const startsWithWhitespace = whitespaceChunks.length > 0 && whitespaceChunks[0] !== "";
 
     for(let classIndex = 0, literalIndex = 0; classIndex < classChunks.length; classIndex++){
 
       const className = classChunks[classIndex];
 
-      const classStart = literalIndex;
-      const classEnd = literalIndex + className.length;
+      const classStart = literalIndex + (startsWithWhitespace ? whitespaceChunks[classIndex].length : 0);
 
-      literalIndex += classChunks[classIndex].length + whiteSpaceChunks[classIndex].length;
+      literalIndex += classStart + classChunks[classIndex].length;
 
       for(
         let i = 0,

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -137,13 +137,15 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
             const [balancedContent] = extractBalanced(className.slice(start), "(", ")");
 
+            if(!balancedContent){
+              continue;
+            }
+
             const end = start + balancedContent.length + 2;
 
             const fixedVariable = `[var(${balancedContent})]`;
 
             const [literalStart] = literal.range;
-
-            console.log({ end: literalStart + classStart + end + 1, start: literalStart + classStart + start + 1 });
 
             ctx.report({
               data: {
@@ -171,6 +173,10 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
             const [balancedArbitraryContent] = extractBalanced(className.slice(start), "[", "]");
             const [balancedVariableContent] = extractBalanced(className.slice(start));
+
+            if(!balancedArbitraryContent || !balancedVariableContent){
+              continue;
+            }
 
             const end = start + balancedArbitraryContent.length + 2;
 

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -179,7 +179,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
                   literalStart + classStart + end + 1
                 ], fixedVariable);
               },
-              loc: getExactClassLocation(literal, incorrectSyntax),
+              loc: getExactClassLocation(literal, incorrectSyntax, true),
               message: "Incorrect variable syntax: \"{{ incorrectSyntax }}\"."
             });
           }

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -112,7 +112,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
       literalIndex += className.length;
 
       if(!startsWithWhitespace){
-        literalIndex += whitespaceChunks[classIndex].length;
+        literalIndex += whitespaceChunks[classIndex + 1].length;
       }
 
       for(
@@ -129,7 +129,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
           if(isInsideVar){
             continue;
           }
-
+          // text-red-500 bg-(--brand)
           if(isBeginningOfParenthesizedVariable(characters)){
             isInsideVar = true;
 

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -186,8 +186,6 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
             const [literalStart] = literal.range;
 
-            console.log({ classStart, end: literalStart + classStart + end + 1, literalStart, start: literalStart + classStart + start + 1 });
-
             ctx.report({
               data: {
                 incorrectSyntax

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -1,0 +1,281 @@
+import {
+  DEFAULT_ATTRIBUTE_NAMES,
+  DEFAULT_CALLEE_NAMES,
+  DEFAULT_TAG_NAMES,
+  DEFAULT_VARIABLE_NAMES
+} from "better-tailwindcss:options:default-options.js";
+import {
+  ATTRIBUTE_SCHEMA,
+  CALLEE_SCHEMA,
+  TAG_SCHEMA,
+  VARIABLE_SCHEMA
+} from "better-tailwindcss:options:descriptions.js";
+import { createRuleListener } from "better-tailwindcss:utils:rule.js";
+import {
+  getCommonOptions,
+  getExactClassLocation,
+  splitClasses,
+  splitWhitespaces
+} from "better-tailwindcss:utils:utils.js";
+
+import type { Rule } from "eslint";
+
+import type { Literal } from "better-tailwindcss:types:ast.js";
+import type {
+  AttributeOption,
+  CalleeOption,
+  ESLintRule,
+  TagOption,
+  VariableOption
+} from "better-tailwindcss:types:rule.js";
+
+
+export type Options = [
+  Partial<
+    AttributeOption &
+    CalleeOption &
+    TagOption &
+    VariableOption &
+    {
+      syntax?: "arbitrary" | "parentheses";
+    }
+  >
+];
+
+
+const defaultOptions = {
+  attributes: DEFAULT_ATTRIBUTE_NAMES,
+  callees: DEFAULT_CALLEE_NAMES,
+  syntax: "parentheses",
+  tags: DEFAULT_TAG_NAMES,
+  variables: DEFAULT_VARIABLE_NAMES
+} as const satisfies Options[0];
+
+const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-consistent-variable-syntax.md";
+
+export const enforceConsistentVariableSyntax: ESLintRule<Options> = {
+  name: "enforce-consistent-variable-syntax" as const,
+  rule: {
+    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    meta: {
+      docs: {
+        description: "Enforce consistent syntax for css variables.",
+        recommended: false,
+        url: DOCUMENTATION_URL
+      },
+      fixable: "code",
+      schema: [
+        {
+          additionalProperties: false,
+          properties: {
+            ...CALLEE_SCHEMA,
+            ...ATTRIBUTE_SCHEMA,
+            ...VARIABLE_SCHEMA,
+            ...TAG_SCHEMA,
+            syntax: {
+              default: "parentheses",
+              description: "Preferred syntax for CSS variables. 'arbitrary' uses [var(--foo)], 'parentheses' uses (--foo).",
+              enum: ["arbitrary", "parentheses"],
+              type: "string"
+            }
+          },
+          type: "object"
+        }
+      ],
+      type: "problem"
+    }
+  }
+};
+
+function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
+
+  for(const literal of literals){
+
+    const { syntax } = getOptions(ctx);
+
+    const classChunks = splitClasses(literal.content);
+    const whiteSpaceChunks = splitWhitespaces(literal.content);
+
+    for(let classIndex = 0, literalIndex = 0; classIndex < classChunks.length; classIndex++){
+
+      const className = classChunks[classIndex];
+
+      const classStart = literalIndex;
+      const classEnd = literalIndex + className.length;
+
+      literalIndex += classChunks[classIndex].length + whiteSpaceChunks[classIndex].length;
+
+      for(
+        let i = 0,
+          isInsideVar: boolean = false,
+          isInsideBrackets: boolean = false,
+          characters: string[] = [];
+        i < className.length;
+        i++){
+        characters.push(className[i]);
+
+        if(syntax === "arbitrary"){
+
+          if(isInsideVar){
+            continue;
+          }
+
+          if(isBeginningOfParenthesizedVariable(characters)){
+            isInsideVar = true;
+
+            const start = i + 1 - 3;
+
+            const [balancedContent] = extractBalanced(className.slice(start), "(", ")");
+
+            const end = start + balancedContent.length + 2;
+
+            const fixedVariable = `[var(${balancedContent})]`;
+
+            const [literalStart] = literal.range;
+
+            ctx.report({
+              data: {
+                incorrectSyntax: balancedContent
+              },
+              fix(fixer) {
+                return fixer.replaceTextRange([
+                  literalStart + classStart + start + 1,
+                  literalStart + classStart + end + 1
+                ], fixedVariable);
+              },
+              loc: getExactClassLocation(literal, balancedContent),
+              message: "Incorrect variable syntax: \"{{ incorrectSyntax }}\"."
+            });
+          }
+        }
+
+        if(syntax === "parentheses"){
+          if(isBeginningOfArbitraryVariable(characters)){
+            if(isInsideBrackets){
+              continue;
+            }
+
+            const start = i + 1 - (findOpeningBracketOffset(characters) ?? 0);
+
+            const [balancedArbitraryContent] = extractBalanced(className.slice(start), "[", "]");
+            const [balancedVariableContent] = extractBalanced(className.slice(start));
+
+            const end = start + balancedArbitraryContent.length + 2;
+
+            const fixedVariable = `(${balancedVariableContent})`;
+
+            const incorrectSyntax = `[${balancedArbitraryContent}]`;
+
+            const [literalStart] = literal.range;
+
+            ctx.report({
+              data: {
+                incorrectSyntax
+              },
+              fix(fixer) {
+                return fixer.replaceTextRange([
+                  literalStart + classStart + start + 1,
+                  literalStart + classStart + end + 1
+                ], fixedVariable);
+              },
+              loc: getExactClassLocation(literal, incorrectSyntax),
+              message: "Incorrect variable syntax: \"{{ incorrectSyntax }}\"."
+            });
+          }
+        }
+      }
+    }
+
+  }
+}
+
+function isBeginningOfParenthesizedVariable(characters: string[]): boolean {
+  return characters.slice(-6).join("") !== "var(--" && characters.slice(-3).join("") === "(--";
+}
+
+function isBeginningOfArbitraryVariable(characters: string[]): boolean {
+  const toBe = "[var(--".split("");
+
+  for(let i = characters.length - 1; i >= 0; i--){
+
+    if(toBe.length === 0){
+      return true;
+    }
+
+    const expectedChar = toBe[toBe.length - 1];
+    const character = characters[i];
+
+    if(i < 0){
+      return false;
+    }
+
+    if(character !== expectedChar){
+      if(expectedChar === "[" && character === "_"){
+        continue;
+      }
+
+      return false;
+    }
+
+    toBe.pop();
+  }
+
+  return false;
+}
+
+function findOpeningBracketOffset(characters: string[]) {
+  for(let i = characters.length - 1; i >= 0; i--){
+    if(characters[i] === "["){
+      return characters.length - i;
+    }
+  }
+}
+
+function extractBalanced(className: string, start = "(", end = ")"): string[] {
+  const results: string[] = [];
+  const characters: string[] = [];
+
+  for(let i = 0, parenthesesCount = 0, hasStarted: boolean = false; i < className.length; i++){
+    if(className[i] === start){
+      parenthesesCount++;
+
+      if(!hasStarted){
+        hasStarted = true;
+        continue;
+      }
+    }
+
+    if(!hasStarted){
+      continue;
+    }
+
+    if(className[i] === end){
+      parenthesesCount--;
+
+      if(parenthesesCount === 0){
+        results.push(characters.join(""));
+        characters.length = 0;
+        hasStarted = false;
+        continue;
+      }
+    }
+
+    characters.push(className[i]);
+  }
+
+  return results;
+}
+
+export function getOptions(ctx: Rule.RuleContext) {
+
+  const options: Options[0] = ctx.options[0] ?? {};
+  const common = getCommonOptions(ctx);
+
+  const syntax = options.syntax ?? defaultOptions.syntax;
+
+  return {
+    ...common,
+    syntax
+  };
+
+}

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -98,13 +98,22 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
     const startsWithWhitespace = whitespaceChunks.length > 0 && whitespaceChunks[0] !== "";
 
+
     for(let classIndex = 0, literalIndex = 0; classIndex < classChunks.length; classIndex++){
 
       const className = classChunks[classIndex];
 
-      const classStart = literalIndex + (startsWithWhitespace ? whitespaceChunks[classIndex].length : 0);
+      if(startsWithWhitespace){
+        literalIndex += whitespaceChunks[classIndex].length;
+      }
 
-      literalIndex += classStart + classChunks[classIndex].length;
+      const classStart = literalIndex;
+
+      literalIndex += className.length;
+
+      if(!startsWithWhitespace){
+        literalIndex += whitespaceChunks[classIndex].length;
+      }
 
       for(
         let i = 0,
@@ -133,6 +142,8 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
             const fixedVariable = `[var(${balancedContent})]`;
 
             const [literalStart] = literal.range;
+
+            console.log({ end: literalStart + classStart + end + 1, start: literalStart + classStart + start + 1 });
 
             ctx.report({
               data: {
@@ -168,6 +179,8 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
             const incorrectSyntax = `[${balancedArbitraryContent}]`;
 
             const [literalStart] = literal.range;
+
+            console.log({ classStart, end: literalStart + classStart + end + 1, literalStart, start: literalStart + classStart + start + 1 });
 
             ctx.report({
               data: {

--- a/src/rules/no-duplicate-classes.ts
+++ b/src/rules/no-duplicate-classes.ts
@@ -155,7 +155,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         fix(fixer) {
           return fixer.replaceTextRange(literal.range, fixedClasses);
         },
-        loc: getExactClassLocation(literal, className, true),
+        loc: getExactClassLocation(literal, className, false, true),
         message: "Duplicate classname: \"{{ duplicateClassname }}\"."
       });
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -111,9 +111,13 @@ export function escapeForRegex(word: string) {
   return word.replace(/[$()*+.?[\\\]^{|}]/g, "\\$&");
 }
 
-export function getExactClassLocation(literal: Literal, className: string, lastIndex?: boolean) {
+export function getExactClassLocation(literal: Literal, className: string, partial: boolean = false, lastIndex: boolean = false) {
   const escapedClass = escapeForRegex(className);
-  const regex = new RegExp(`(?:^|\\s+)(${escapedClass})(?=\\s+|$)`, "g");
+
+  const regex = partial
+    ? new RegExp(`(${escapedClass})`, "g")
+    : new RegExp(`(?:^|\\s+)(${escapedClass})(?=\\s+|$)`, "g");
+
   const [...matches] = literal.content.matchAll(regex);
 
   const match = lastIndex ? matches.at(-1) : matches.at(0);


### PR DESCRIPTION
Enforce consistent css variable syntax in tailwindcss class strings.

```tsx
// ❌ BAD: Incorrect css variable syntax with option `syntax: "parentheses"`
<div class="bg-[var(--primary)]" />;
```

```tsx
// ✅ GOOD: With option `syntax: "parentheses"`
<div class="bg-(--primary)" />;
```

```tsx
// ❌ BAD: Incorrect css variable syntax with option `syntax: "arbitrary"`
<div class="bg-(--primary)" />;
```

```tsx
// ✅ GOOD: With option `syntax: "arbitrary"`
<div class="bg-[var(--primary)]" />;
```
