### PR TITLE
feat: add support for astro syntactic sugar

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,6 +29,7 @@
     "quasis",
     "shadcn",
     "synckit",
-    "Tmpl"
+    "Tmpl",
+    "astro"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ ESLint plugin with formatting and linting rules to help you write cleaner, more 
 
 The formatting rules focus on improving readability by automatically breaking up long Tailwind class strings into multiple lines and sorting/grouping them in a logical order. The linting rules enforce best practices and catch potential issues, ensuring that you're writing valid Tailwind CSS.  
 
-This plugin supports a wide range of projects, including React, Solid.js, Qwik, Svelte, Vue, Angular, HTML or plain JavaScript or TypeScript.  
+This plugin supports a wide range of projects, including React, Solid.js, Qwik, Svelte, Vue, Astro, Angular, HTML or plain JavaScript or TypeScript.  
 
 <br/>
 <br/>
@@ -141,8 +141,9 @@ Depending on the flavor you are using, you may need to install and configure the
 - [TSX (React, Solid.js, Qwik) with TypeScript support](docs/parsers/tsx.md)
 - [Svelte](docs/parsers/svelte.md)
 - [Vue](docs/parsers/vue.md)
-- [HTML](docs/parsers/html.md)
+- [Astro](docs/parsers/astro.md)
 - [Angular](docs/parsers/angular.md)
+- [HTML](docs/parsers/html.md)
 - [Plain JavaScript](docs/parsers/javascript.md)
 - [Plain TypeScript](docs/parsers/typescript.md)
 

--- a/docs/parsers/astro.md
+++ b/docs/parsers/astro.md
@@ -1,0 +1,85 @@
+# Astro
+
+To use ESLint with Astro files, first install the [astro-eslint-parser](https://github.com/ota-meshi/astro-eslint-parser). Then, configure ESLint to use this parser for Astro files.
+
+To use TypeScript within Astro files, you can also install the [@typescript-eslint/parser](https://typescript-eslint.io/packages/parser) and configure it via the `parser` option in the `languageOptions` section of your ESLint configuration.
+
+To enable eslint-plugin-better-tailwindcss, you need to add it to the plugins section of your eslint configuration and enable the rules you want to use.
+
+<br/>
+
+## Usage
+
+### Flat config
+
+Read more about the new [ESLint flat config format](https://eslint.org/docs/latest/use/configure/configuration-files-new)
+
+```js
+// eslint.config.js
+import eslintParserTypeScript from "@typescript-eslint/parser";
+import eslintParserAstro from "astro-eslint-parser";
+import eslintPluginBetterTailwindcss from "eslint-plugin-better-tailwindcss";
+
+export default [
+  {
+    files: ["*.astro"],
+    languageOptions: {
+      parser: eslintParserAstro,
+      parserOptions: {
+        // optionally use TypeScript parser within for Astro files
+        parser: eslintParserTypeScript
+      }
+    },
+    plugins: {
+      "better-tailwindcss": eslintPluginBetterTailwindcss
+    },
+    rules: {
+      // enable all recommended rules to report a warning
+      ...eslintPluginBetterTailwindcss.configs["recommended-warn"].rules,
+      // enable all recommended rules to report an error
+      ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
+
+      // or configure rules individually
+      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+    }
+  }
+];
+```
+
+<br/>
+
+```jsonc
+// .eslintrc.json
+{
+  "extends": [
+    // enable all recommended rules to report a warning
+    "plugin:better-tailwindcss/recommended-warn",
+    // enable all recommended rules to report an error
+    "plugin:better-tailwindcss/recommended-error"
+  ],
+  "parser": "astro-eslint-parser",
+  "parserOptions": {
+    // optionally use TypeScript parser within for Astro files
+    "parser": "@typescript-eslint/parser"
+  },
+  "plugins": ["better-tailwindcss"],
+  "rules": {
+    // or configure rules individually
+    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+  }
+}
+```
+
+<br/>
+
+### Editor configuration
+
+#### VSCode
+
+To enable the [VSCode ESLint plugin](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) to validate Astro files, add the following to your `.vscode/settings.json`:
+
+```jsonc
+{
+  "eslint.validate": [/* ...other formats */, "astro"]
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/estree-jsx": "^1.0.5",
         "@types/node": "^22.15.23",
         "@typescript-eslint/parser": "^8.33.0",
+        "astro-eslint-parser": "^1.2.2",
         "changelogen": "^0.6.1",
         "cspell": "^9.0.2",
         "es-html-parser": "^0.2.0",
@@ -154,6 +155,13 @@
       "engines": {
         "node": "^18.19.1 || ^20.11.1 || >=22.0.0"
       }
+    },
+    "node_modules/@astrojs/compiler": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-2.12.0.tgz",
+      "integrity": "sha512-7bCjW6tVDpUurQLeKBUN9tZ5kSv5qYrGmcn0sG0IwacL7isR2ZbyyA3AdZ4uxsuUFOS2SlgReTH7wkxO6zpqWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.27.1",
@@ -2998,6 +3006,94 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/astro-eslint-parser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/astro-eslint-parser/-/astro-eslint-parser-1.2.2.tgz",
+      "integrity": "sha512-JepyLROIad6f44uyqMF6HKE2QbunNzp3mYKRcPoDGt0QkxXmH222FAFC64WTyQu2Kg8NNEXHTN/sWuUId9sSxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/compiler": "^2.0.0",
+        "@typescript-eslint/scope-manager": "^7.0.0 || ^8.0.0",
+        "@typescript-eslint/types": "^7.0.0 || ^8.0.0",
+        "astrojs-compiler-sync": "^1.0.0",
+        "debug": "^4.3.4",
+        "entities": "^6.0.0",
+        "eslint-scope": "^8.0.1",
+        "eslint-visitor-keys": "^4.0.0",
+        "espree": "^10.0.0",
+        "fast-glob": "^3.3.3",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      }
+    },
+    "node_modules/astro-eslint-parser/node_modules/entities": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.0.tgz",
+      "integrity": "sha512-aKstq2TDOndCn4diEyp9Uq/Flu2i1GlLkc6XIDQSDMuaFE3OPW5OphLCyQ5SpSJZTb4reN+kTcYru5yIfXoRPw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/astrojs-compiler-sync": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/astrojs-compiler-sync/-/astrojs-compiler-sync-1.1.1.tgz",
+      "integrity": "sha512-0mKvB9sDQRIZPsEJadw6OaFbGJ92cJPPR++ICca9XEyiUAZqgVuk25jNmzHPT0KF80rI94trSZrUR5iHFXGGOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "synckit": "^0.11.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.9.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "@astrojs/compiler": ">=0.27.0"
+      }
+    },
+    "node_modules/astrojs-compiler-sync/node_modules/@pkgr/core": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.4.tgz",
+      "integrity": "sha512-ROFF39F6ZrnzSUEmQQZUar0Jt4xVoP9WnDRdWwF4NNcXs3xBTLgBUDoOwW141y1jP+S8nahIbdxbFC7IShw9Iw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/pkgr"
+      }
+    },
+    "node_modules/astrojs-compiler-sync/node_modules/synckit": {
+      "version": "0.11.8",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
+      "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@pkgr/core": "^0.2.4"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/synckit"
       }
     },
     "node_modules/axobject-query": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eslint-plugin-better-tailwindcss",
-  "version": "3.0.0",
+  "version": "3.1.0-astro.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eslint-plugin-better-tailwindcss",
-      "version": "3.0.0",
+      "version": "3.1.0-astro.0",
       "license": "MIT",
       "dependencies": {
         "enhanced-resolve": "^5.18.1",

--- a/package.json
+++ b/package.json
@@ -83,13 +83,14 @@
     "synckit": "0.9.2"
   },
   "devDependencies": {
-    "@angular/compiler": "^19.2.13",
     "@angular-eslint/template-parser": "^19.6.0",
+    "@angular/compiler": "^19.2.13",
     "@html-eslint/parser": "^0.41.0",
     "@schoero/configs": "^1.4.1",
     "@types/estree-jsx": "^1.0.5",
     "@types/node": "^22.15.23",
     "@typescript-eslint/parser": "^8.33.0",
+    "astro-eslint-parser": "^1.2.2",
     "changelogen": "^0.6.1",
     "cspell": "^9.0.2",
     "es-html-parser": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.0.0",
+  "version": "3.1.0-astro.0",
   "type": "module",
   "name": "eslint-plugin-better-tailwindcss",
   "description": "auto-wraps tailwind classes after a certain print width or class count into multiple lines to improve readability.",
@@ -83,8 +83,8 @@
     "synckit": "0.9.2"
   },
   "devDependencies": {
-    "@angular-eslint/template-parser": "^19.6.0",
     "@angular/compiler": "^19.2.13",
+    "@angular-eslint/template-parser": "^19.6.0",
     "@html-eslint/parser": "^0.41.0",
     "@schoero/configs": "^1.4.1",
     "@types/estree-jsx": "^1.0.5",

--- a/src/options/default-options.ts
+++ b/src/options/default-options.ts
@@ -66,6 +66,18 @@ export const DEFAULT_ATTRIBUTE_NAMES = [
         match: MatcherType.ObjectKey
       }
     ]
+  ],
+
+  // astro
+  [
+    "^class:list$", [
+      {
+        match: MatcherType.String
+      },
+      {
+        match: MatcherType.ObjectKey
+      }
+    ]
   ]
 ] satisfies Attributes;
 

--- a/src/parsers/jsx.test.ts
+++ b/src/parsers/jsx.test.ts
@@ -5,7 +5,6 @@ import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests:utils.js";
 
 
 describe("jsx", () => {
-
   it("should match attribute names via regex", () => {
     lint(sortClasses, TEST_SYNTAXES, {
       invalid: [
@@ -18,5 +17,20 @@ describe("jsx", () => {
       ]
     });
   });
+});
 
+
+describe("astro (jsx)", () => {
+  it("should match astro syntactic sugar", () => {
+    lint(sortClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          astro: `<img class:list="b a" />`,
+          astroOutput: `<img class:list="a b" />`,
+          errors: 1,
+          options: [{ order: "asc" }]
+        }
+      ]
+    });
+  });
 });

--- a/src/parsers/jsx.ts
+++ b/src/parsers/jsx.ts
@@ -40,13 +40,19 @@ export function getLiteralsByJSXAttribute(ctx: Rule.RuleContext, attribute: JSXA
   const literals = attributes.reduce<Literal[]>((literals, attributes) => {
     if(!value){ return literals; }
 
+    const name = getAttributeName(attribute);
+
+    if(typeof name !== "string"){
+      return literals;
+    }
+
     if(isAttributesName(attributes)){
-      if(typeof attribute.name.name !== "string" || !matchesName(attributes.toLowerCase(), attribute.name.name.toLowerCase())){ return literals; }
+      if(!matchesName(attributes.toLowerCase(), name.toLowerCase())){ return literals; }
       literals.push(...getLiteralsByJSXAttributeValue(ctx, value));
     } else if(isAttributesRegex(attributes)){
       literals.push(...getLiteralsByESNodeAndRegex(ctx, attribute, attributes));
     } else if(isAttributesMatchers(attributes)){
-      if(typeof attribute.name.name !== "string" || !matchesName(attributes[0].toLowerCase(), attribute.name.name.toLowerCase())){ return literals; }
+      if(!matchesName(attributes[0].toLowerCase(), name.toLowerCase())){ return literals; }
       literals.push(...getLiteralsByESMatchers(ctx, value, attributes[1]));
     }
 
@@ -64,6 +70,15 @@ export function getAttributesByJSXElement(ctx: Rule.RuleContext, node: JSXOpenin
     }
     return acc;
   }, []);
+}
+
+function getAttributeName(attribute: JSXAttribute): string | undefined {
+  if(attribute.name.type === "JSXIdentifier"){
+    return attribute.name.name;
+  }
+  if(attribute.name.type === "JSXNamespacedName"){
+    return `${attribute.name.namespace.name}:${attribute.name.name.name}`;
+  }
 }
 
 function getLiteralsByJSXAttributeValue(ctx: Rule.RuleContext, value: JSXAttribute["value"]): Literal[] {

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -65,10 +65,8 @@ export function createRuleListener(ctx: Rule.RuleContext, options: Options, lint
       for(const jsxAttribute of jsxAttributes){
 
         const attributeValue = jsxAttribute.value;
-        const attributeName = jsxAttribute.name.name;
 
         if(!attributeValue){ continue; }
-        if(typeof attributeName !== "string"){ continue; }
 
         const literals = getLiteralsByJSXAttribute(ctx, jsxAttribute, attributes);
         lintLiterals(ctx, literals);

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -3,6 +3,7 @@ import { normalize } from "node:path";
 
 import eslintParserAngular from "@angular-eslint/template-parser";
 import eslintParserHTML from "@html-eslint/parser";
+import eslintParserAstro from "astro-eslint-parser";
 import { RuleTester } from "eslint";
 import { createTag } from "proper-tags";
 import eslintParserSvelte from "svelte-eslint-parser";
@@ -17,6 +18,9 @@ import type { ESLintRule } from "better-tailwindcss:types:rule.js";
 export const TEST_SYNTAXES = {
   angular: {
     languageOptions: { parser: eslintParserAngular }
+  },
+  astro: {
+    languageOptions: { parser: eslintParserAstro }
   },
   html: {
     languageOptions: { parser: eslintParserHTML }


### PR DESCRIPTION
Add support for the [`class:list` syntactic sugar](https://docs.astro.build/en/reference/directives-reference/#classlist) in astro.

```astro
<img class:list={[ 'font-bold', { underline: true }, [ 'italic' ] ]} />
```

closes #102 