### PR TITLE
fix: ignore prefix in groups

### DIFF
--- a/docs/rules/multiline.md
+++ b/docs/rules/multiline.md
@@ -26,7 +26,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 ### `group`
 
-  Defines how different groups of classes should be separated. A group is a set of classes that share the same modifier/variant.
+  Defines how different groups of classes should be separated. A group is a set of classes that share the same variant.
 
   **Type**: `"emptyLine" | "never" | "newLine"`  
   **Default**: `"newLine"`  
@@ -35,7 +35,7 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 ### `preferSingleLine`
 
-  Prefer a single line for different modifiers/variants. When set to `true`, the rule will keep all modifiers/variants on a single line until the line exceeds the `printWidth` or `classesPerLine` limit.
+  Prefer a single line for different variants. When set to `true`, the rule will keep all variants on a single line until the line exceeds the `printWidth` or `classesPerLine` limit.
 
   **Type**: `boolean`  
   **Default**: `false`  
@@ -99,9 +99,31 @@ Enforce tailwind classes to be broken up into multiple lines. It is possible to 
 
 <br/>
 
+### `entryPoint`
+
+  The path to the entry file of the css based tailwind config (eg: `src/global.css`). This can also be set globally via the [`settings` object](../settings/settings.md#entrypoint).  
+  If not specified, the plugin will fall back to the default configuration.  
+
+  **Type**: `string`  
+  **Default**: `undefined`
+
+<br/>
+
+### `tailwindConfig`
+
+  The path to the `tailwind.config.js` file. If not specified, the plugin will try to find it automatically or falls back to the default configuration.  
+  This can also be set globally via the [`settings` object](../settings/settings.md#tailwindConfig).  
+
+  For tailwindcss v4 and the css based config, use the [`entryPoint`](#entrypoint) option instead.
+
+  **Type**: `string`  
+  **Default**: `undefined`
+
+<br/>
+
 ## Examples
 
-With the default options, a class name will be broken up into multiple lines and grouped by their modifiers. Groups are separated by an empty line.  
+With the default options, a class name will be broken up into multiple lines and grouped by their variants. Groups are separated by an empty line.  
 
 The following examples show how the rule behaves with different options:
 

--- a/src/rules/multiline.test.ts
+++ b/src/rules/multiline.test.ts
@@ -1,8 +1,9 @@
+import { getTailwindcssVersion, TailwindcssVersion } from "src/tailwind/utils/version.js";
 import { describe, it } from "vitest";
 
 import { multiline } from "better-tailwindcss:rules/multiline.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
-import { dedent } from "better-tailwindcss:tests/utils/template.js";
+import { css, dedent, ts } from "better-tailwindcss:tests/utils/template.js";
 import { MatcherType } from "better-tailwindcss:types/rule.js";
 
 
@@ -1270,6 +1271,74 @@ describe(multiline.name, () => {
       }
     );
 
+  });
+
+  it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should ignore prefixed variants in tailwind <= 3", () => {
+    lint(
+      multiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="tw-a tw-b hover:tw-c focus:tw-d" />`,
+            angularOutput: `<img class="\n  tw-a tw-b\n  hover:tw-c\n  focus:tw-d\n" />`,
+            html: `<img class="tw-a tw-b hover:tw-c focus:tw-d" />`,
+            htmlOutput: `<img class="\n  tw-a tw-b\n  hover:tw-c\n  focus:tw-d\n" />`,
+            jsx: `() => <img class="tw-a tw-b hover:tw-c focus:tw-d" />`,
+            jsxOutput: `() => <img class={\`\n  tw-a tw-b\n  hover:tw-c\n  focus:tw-d\n\`} />`,
+            svelte: `<img class="tw-a tw-b hover:tw-c focus:tw-d" />`,
+            svelteOutput: `<img class="\n  tw-a tw-b\n  hover:tw-c\n  focus:tw-d\n" />`,
+            vue: `<template><img class="tw-a tw-b hover:tw-c focus:tw-d" /></template>`,
+            vueOutput: `<template><img class="\n  tw-a tw-b\n  hover:tw-c\n  focus:tw-d\n" /></template>`,
+
+            errors: 1,
+            files: {
+              "tailwind.config.js": ts`
+                export default {
+                  prefix: 'tw-',
+                };
+              `
+            },
+            options: [{
+              tailwindConfig: "./tailwind.config.js"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should ignore prefixed variants in tailwind >= 4", () => {
+    lint(
+      multiline,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="tw:a tw:b tw:hover:c tw:focus:d" />`,
+            angularOutput: `<img class="\n  tw:a tw:b\n  tw:hover:c\n  tw:focus:d\n" />`,
+            html: `<img class="tw:a tw:b tw:hover:c tw:focus:d" />`,
+            htmlOutput: `<img class="\n  tw:a tw:b\n  tw:hover:c\n  tw:focus:d\n" />`,
+            jsx: `() => <img class="tw:a tw:b tw:hover:c tw:focus:d" />`,
+            jsxOutput: `() => <img class={\`\n  tw:a tw:b\n  tw:hover:c\n  tw:focus:d\n\`} />`,
+            svelte: `<img class="tw:a tw:b tw:hover:c tw:focus:d" />`,
+            svelteOutput: `<img class="\n  tw:a tw:b\n  tw:hover:c\n  tw:focus:d\n" />`,
+            vue: `<template><img class="tw:a tw:b tw:hover:c tw:focus:d" /></template>`,
+            vueOutput: `<template><img class="\n  tw:a tw:b\n  tw:hover:c\n  tw:focus:d\n" /></template>`,
+
+            errors: 1,
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss" prefix(tw);
+              `
+            },
+            options: [{
+              entryPoint: "./tailwind.css"
+            }]
+          }
+        ]
+      }
+    );
   });
 
 });

--- a/src/tailwind/api/interface.ts
+++ b/src/tailwind/api/interface.ts
@@ -1,3 +1,5 @@
+import type { TailwindcssVersion } from "src/tailwind/utils/version.js";
+
 import type { Warning } from "better-tailwindcss:utils/utils.js";
 
 
@@ -18,6 +20,20 @@ export interface GetUnregisteredClassesRequest {
   configPath?: string;
 }
 export type GetUnregisteredClassesResponse = [unregisteredClasses: string[], warnings: ConfigWarning[]];
+
+
+export interface GetVersionRequest {
+  cwd: string;
+  configPath?: string;
+}
+export type GetVersionResponse = [version: TailwindcssVersion];
+
+
+export interface GetPrefixRequest {
+  cwd: string;
+  configPath?: string;
+}
+export type GetPrefixResponse = [prefix: string, warnings: ConfigWarning[]];
 
 
 export interface GetConflictingClassesRequest {

--- a/src/tailwind/async/prefix.async.ts
+++ b/src/tailwind/async/prefix.async.ts
@@ -1,0 +1,12 @@
+import { runAsWorker } from "synckit";
+
+import type { GetUnregisteredClassesRequest } from "../api/interface.js";
+import type { SupportedTailwindVersion } from "../utils/version.js";
+
+
+let getUnregisteredClassesModule: typeof import("../v3/prefix.js") | typeof import("../v4/prefix.js");
+
+runAsWorker(async (version: SupportedTailwindVersion, request: GetUnregisteredClassesRequest) => {
+  getUnregisteredClassesModule ??= await import(`../v${version}/prefix.js`);
+  return getUnregisteredClassesModule.getPrefix(request);
+});

--- a/src/tailwind/async/prefix.sync.ts
+++ b/src/tailwind/async/prefix.sync.ts
@@ -1,0 +1,43 @@
+// runner.js
+import { resolve } from "node:path";
+import { env } from "node:process";
+
+import { createSyncFn, TsRunner } from "synckit";
+
+import { getTailwindcssVersion, isSupportedVersion } from "../utils/version.js";
+
+import type { GetPrefixRequest, GetPrefixResponse } from "../api/interface.js";
+import type { SupportedTailwindVersion } from "../utils/version.js";
+
+
+const workerPath = getWorkerPath();
+const version = getTailwindcssVersion();
+const workerOptions = getWorkerOptions();
+
+const getPrefixSync = createSyncFn<(version: SupportedTailwindVersion, request: GetPrefixRequest) => any>(workerPath, workerOptions);
+
+
+export function getPrefix(request: GetPrefixRequest): GetPrefixResponse {
+  if(!isSupportedVersion(version.major)){
+    throw new Error(`Unsupported Tailwind CSS version: ${version.major}`);
+  }
+
+  return getPrefixSync(version.major, request) as GetPrefixResponse;
+}
+
+
+function getWorkerPath() {
+  return resolve(getCurrentDirectory(), "./prefix.async.js");
+}
+
+function getWorkerOptions() {
+  if(env.NODE_ENV === "test"){
+    return { execArgv: ["--import", TsRunner.TSX] };
+  }
+}
+
+function getCurrentDirectory() {
+  // eslint-disable-next-line eslint-plugin-typescript/prefer-ts-expect-error
+  // @ts-ignore - `import.meta` doesn't exist in CommonJS -> will be transformed in build step
+  return import.meta.dirname;
+}

--- a/src/tailwind/v3/prefix.ts
+++ b/src/tailwind/v3/prefix.ts
@@ -1,0 +1,24 @@
+import { findTailwindConfig } from "./config.js";
+import { createTailwindContextFromConfigFile } from "./context.js";
+
+import type { ConfigWarning, GetPrefixRequest, GetPrefixResponse } from "../api/interface.js";
+
+
+export async function getPrefix({ configPath, cwd }: GetPrefixRequest): Promise<GetPrefixResponse> {
+  const warnings: ConfigWarning[] = [];
+
+  const config = findTailwindConfig(cwd, configPath);
+
+  if(!config){
+    warnings.push({
+      option: "entryPoint",
+      title: `No tailwind css config found at \`${configPath}\``
+    });
+  }
+
+  const context = await createTailwindContextFromConfigFile(config);
+
+  const prefix = context.tailwindConfig.prefix ?? "";
+
+  return [prefix, warnings];
+}

--- a/src/tailwind/v4/prefix.ts
+++ b/src/tailwind/v4/prefix.ts
@@ -1,0 +1,33 @@
+import { findDefaultConfig, findTailwindConfigPath } from "./config.js";
+import { createTailwindContextFromEntryPoint } from "./context.js";
+
+import type { ConfigWarning, GetPrefixRequest, GetPrefixResponse } from "../api/interface.js";
+
+
+export async function getPrefix({ configPath, cwd }: GetPrefixRequest): Promise<GetPrefixResponse> {
+  const warnings: ConfigWarning[] = [];
+
+  const config = findTailwindConfigPath(cwd, configPath);
+  const defaultConfig = findDefaultConfig(cwd);
+
+  if(!config){
+    warnings.push({
+      option: "entryPoint",
+      title: configPath
+        ? `No tailwind css config found at \`${configPath}\``
+        : "No tailwind css entry point configured"
+    });
+  }
+
+  const path = config ?? defaultConfig;
+
+  if(!path){
+    throw new Error("Could not find a valid Tailwind CSS configuration");
+  }
+
+  const context = await createTailwindContextFromEntryPoint(path);
+
+  const prefix = context.theme.prefix ?? "";
+
+  return [prefix, warnings];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,8 @@
       "better-tailwindcss:rules/*": ["src/rules/*"],
       "better-tailwindcss:tests/*": ["tests/*"],
       "better-tailwindcss:types/*": ["src/types/*"],
-      "better-tailwindcss:utils/*": ["src/utils/*"]
+      "better-tailwindcss:utils/*": ["src/utils/*"],
+      "better-tailwindcss:tailwind/*": ["src/tailwind/*"]
     },
 
     // imports


### PR DESCRIPTION
fixes #108 

Automatically ignores the configured [`prefix`](https://tailwindcss.com/docs/styling-with-utility-classes#using-the-prefix-option) when grouped by variants.

```jsx
<img class={`
  tw:a tw:b
  tw:hover:c
  tw:focus:d
`} />
```
