### PR TITLE
fix/prefixed groups and peers

### DIFF
--- a/docs/rules/no-unregistered-classes.md
+++ b/docs/rules/no-unregistered-classes.md
@@ -10,12 +10,8 @@ Disallow unregistered classes in tailwindcss class strings. Unregistered classes
 
   List of classes that should not report an error. The entries in this list are treated as regular expressions.
   
-  The rule works, by checking the output that a given class will produce. By default, the utilities `group` and `peer` are ignored, because they don't produce any css output.
-  
-  If you want to customize the ignore list, it is recommended to add the default options to the ignore override. You can use the function `getDefaultIgnoredUnregisteredClasses()` exported from `/api/defaults` to get the original ignore list.
-
   **Type**: `string[]`  
-  **Default**: `["^group(?:\\/(\\S*))?$", "^peer(?:\\/(\\S*))?$"]`
+  **Default**: `[]`
 
 <br/>
 

--- a/src/rules/multiline.test.ts
+++ b/src/rules/multiline.test.ts
@@ -1293,14 +1293,14 @@ describe(multiline.name, () => {
 
             errors: 1,
             files: {
-              "tailwind.config.js": ts`
+              "tailwind.config.prefix.js": ts`
                 export default {
                   prefix: 'tw-',
                 };
               `
             },
             options: [{
-              tailwindConfig: "./tailwind.config.js"
+              tailwindConfig: "./tailwind.config.prefix.js"
             }]
           }
         ]

--- a/src/rules/no-unregistered-classes.test.ts
+++ b/src/rules/no-unregistered-classes.test.ts
@@ -180,40 +180,6 @@ describe(noUnregisteredClasses.name, () => {
     );
   });
 
-  it("should not report on tailwind utility classes that don't produce a css output", () => {
-    lint(
-      noUnregisteredClasses,
-      TEST_SYNTAXES,
-      {
-        valid: [
-          {
-            angular: `<img class="group" />`,
-            html: `<img class="group" />`,
-            jsx: `() => <img class="group" />`,
-            svelte: `<img class="group" />`,
-            vue: `<template><img class="group" /></template>`
-          }
-        ]
-      }
-    );
-
-    lint(
-      noUnregisteredClasses,
-      TEST_SYNTAXES,
-      {
-        valid: [
-          {
-            angular: `<img class="group/custom-group" />`,
-            html: `<img class="group/custom-group" />`,
-            jsx: `() => <img class="group/custom-group" />`,
-            svelte: `<img class="group/custom-group" />`,
-            vue: `<template><img class="group/custom-group" /></template>`
-          }
-        ]
-      }
-    );
-  });
-
   it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should not report on registered utility classes in tailwind <= 3", () => {
     lint(
       noUnregisteredClasses,
@@ -240,7 +206,7 @@ describe(noUnregisteredClasses.name, () => {
                   };
                 }
               `,
-              "tailwind.config.js": ts`
+              "tailwind.config.color.js": ts`
                 import { plugin } from "./plugin.js";
 
                 export default {
@@ -258,7 +224,7 @@ describe(noUnregisteredClasses.name, () => {
               `
             },
             options: [{
-              tailwindConfig: "./tailwind.config.js"
+              tailwindConfig: "./tailwind.config.color.js"
             }]
           }
         ]
@@ -384,4 +350,291 @@ describe(noUnregisteredClasses.name, () => {
     );
   });
 
+  it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should work with prefixed tailwind classes tailwind <= 3", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="flex tw-flex hover:tw-flex"/>`,
+            html: `<img class="flex tw-flex hover:tw-flex" />`,
+            jsx: `() => <img class="flex tw-flex hover:tw-flex" />`,
+            svelte: `<img class="flex tw-flex hover:tw-flex" />`,
+            vue: `<template><img class="flex tw-flex hover:tw-flex" /></template>`,
+
+            errors: 1,
+            files: {
+              "tailwind.config.prefix.js": ts`
+                export default {
+                  prefix: 'tw-',
+                };
+              `
+            },
+            options: [{
+              tailwindConfig: "./tailwind.config.prefix.js"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should work with prefixed tailwind classes tailwind >= 4", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="flex tw:flex tw:hover:flex"/>`,
+            html: `<img class="flex tw:flex tw:hover:flex" />`,
+            jsx: `() => <img class="flex tw:flex tw:hover:flex" />`,
+            svelte: `<img class="flex tw:flex tw:hover:flex" />`,
+            vue: `<template><img class="flex tw:flex tw:hover:flex" /></template>`,
+
+            errors: 1,
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss" prefix(tw);
+              `
+            },
+            options: [{
+              entryPoint: "./tailwind.css"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it("should not report on groups and peers", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="group" />`,
+            html: `<img class="group" />`,
+            jsx: `() => <img class="group" />`,
+            svelte: `<img class="group" />`,
+            vue: `<template><img class="group" /></template>`
+          },
+          {
+            angular: `<img class="peer" />`,
+            html: `<img class="peer" />`,
+            jsx: `() => <img class="peer" />`,
+            svelte: `<img class="peer" />`,
+            vue: `<template><img class="peer" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should not report on named groups and peers", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="group/custom-group" />`,
+            html: `<img class="group/custom-group" />`,
+            jsx: `() => <img class="group/custom-group" />`,
+            svelte: `<img class="group/custom-group" />`,
+            vue: `<template><img class="group/custom-group" /></template>`
+          },
+          {
+            angular: `<img class="peer/custom-peer" />`,
+            html: `<img class="peer/custom-peer" />`,
+            jsx: `() => <img class="peer/custom-peer" />`,
+            svelte: `<img class="peer/custom-peer" />`,
+            vue: `<template><img class="peer/custom-peer" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should not report on prefixed groups and peers in tailwind <= 3", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="tw-group"/>`,
+            html: `<img class="tw-group" />`,
+            jsx: `() => <img class="tw-group" />`,
+            svelte: `<img class="tw-group" />`,
+            vue: `<template><img class="tw-group" /></template>`,
+
+            files: {
+              "tailwind.config.js": ts`
+                export default {
+                  prefix: 'tw-',
+                };
+              `
+            },
+            options: [{
+              tailwindConfig: "./tailwind.config.js"
+            }]
+          },
+          {
+            angular: `<img class="tw-peer"/>`,
+            html: `<img class="tw-peer" />`,
+            jsx: `() => <img class="tw-peer" />`,
+            svelte: `<img class="tw-peer" />`,
+            vue: `<template><img class="tw-peer" /></template>`,
+
+            files: {
+              "tailwind.config.js": ts`
+                export default {
+                  prefix: 'tw-',
+                };
+              `
+            },
+            options: [{
+              tailwindConfig: "./tailwind.config.js"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should not report on prefixed named groups and peers in tailwind <= 3", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="tw-group/custom-group"/>`,
+            html: `<img class="tw-group/custom-group" />`,
+            jsx: `() => <img class="tw-group/custom-group" />`,
+            svelte: `<img class="tw-group/custom-group" />`,
+            vue: `<template><img class="tw-group/custom-group" /></template>`,
+
+            files: {
+              "tailwind.config.prefix.js": ts`
+                export default {
+                  prefix: 'tw-',
+                };
+              `
+            },
+            options: [{
+              tailwindConfig: "./tailwind.config.prefix.js"
+            }]
+          },
+          {
+            angular: `<img class="tw-peer/custom-peer"/>`,
+            html: `<img class="tw-peer/custom-peer" />`,
+            jsx: `() => <img class="tw-peer/custom-peer" />`,
+            svelte: `<img class="tw-peer/custom-peer" />`,
+            vue: `<template><img class="tw-peer/custom-peer" /></template>`,
+
+            files: {
+              "tailwind.config.js": ts`
+                export default {
+                  prefix: 'tw-',
+                };
+              `
+            },
+            options: [{
+              tailwindConfig: "./tailwind.config.js"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should not report on prefixed groups and peers in tailwind >= 4", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="tw:group"/>`,
+            html: `<img class="tw:group" />`,
+            jsx: `() => <img class="tw:group" />`,
+            svelte: `<img class="tw:group" />`,
+            vue: `<template><img class="tw:group" /></template>`,
+
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss" prefix(tw);
+              `
+            },
+            options: [{
+              entryPoint: "./tailwind.css"
+            }]
+          },
+          {
+            angular: `<img class="tw:peer"/>`,
+            html: `<img class="tw:peer" />`,
+            jsx: `() => <img class="tw:peer" />`,
+            svelte: `<img class="tw:peer" />`,
+            vue: `<template><img class="tw:peer" /></template>`,
+
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss" prefix(tw);
+              `
+            },
+            options: [{
+              entryPoint: "./tailwind.css"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should not report on prefixed named groups and peers in tailwind >= 4", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="tw:group/custom-group"/>`,
+            html: `<img class="tw:group/custom-group" />`,
+            jsx: `() => <img class="tw:group/custom-group" />`,
+            svelte: `<img class="tw:group/custom-group" />`,
+            vue: `<template><img class="tw:group/custom-group" /></template>`,
+
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss" prefix(tw);
+              `
+            },
+            options: [{
+              entryPoint: "./tailwind.css"
+            }]
+          },
+          {
+            angular: `<img class="tw:peer/custom-peer"/>`,
+            html: `<img class="tw:peer/custom-peer" />`,
+            jsx: `() => <img class="tw:peer/custom-peer" />`,
+            svelte: `<img class="tw:peer/custom-peer" />`,
+            vue: `<template><img class="tw:peer/custom-peer" /></template>`,
+
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss" prefix(tw);
+              `
+            },
+            options: [{
+              entryPoint: "./tailwind.css"
+            }]
+          }
+        ]
+      }
+    );
+  });
 });

--- a/src/tailwind/api/interface.ts
+++ b/src/tailwind/api/interface.ts
@@ -38,7 +38,7 @@ export interface GetPrefixRequest {
   cwd: string;
   configPath?: string;
 }
-export type GetPrefixResponse = [prefix: string, warnings: ConfigWarning[]];
+export type GetPrefixResponse = [prefix: string, suffix: string];
 
 
 export interface GetConflictingClassesRequest {

--- a/src/tailwind/async/prefix.sync.ts
+++ b/src/tailwind/async/prefix.sync.ts
@@ -5,7 +5,7 @@ import { createSyncFn } from "synckit";
 
 import { getWorkerOptions } from "better-tailwindcss:tailwind/utils/worker.js";
 
-import { getTailwindcssVersion, isSupportedVersion } from "../utils/version.js";
+import { getTailwindcssVersion, isSupportedVersion, TailwindcssVersion } from "../utils/version.js";
 
 import type { GetPrefixRequest, GetPrefixResponse } from "../api/interface.js";
 import type { SupportedTailwindVersion } from "../utils/version.js";
@@ -15,15 +15,22 @@ const workerPath = getWorkerPath();
 const version = getTailwindcssVersion();
 const workerOptions = getWorkerOptions();
 
-const getPrefixSync = createSyncFn<(version: SupportedTailwindVersion, request: GetPrefixRequest) => any>(workerPath, workerOptions);
+const getPrefixSync = createSyncFn<(version: SupportedTailwindVersion, request: GetPrefixRequest) => GetPrefixResponse>(workerPath, workerOptions);
 
 
-export function getPrefix(request: GetPrefixRequest): GetPrefixResponse {
+export function getPrefix(request: GetPrefixRequest) {
   if(!isSupportedVersion(version.major)){
     throw new Error(`Unsupported Tailwind CSS version: ${version.major}`);
   }
 
-  return getPrefixSync(version.major, request) as GetPrefixResponse;
+  const [prefix] = getPrefixSync(version.major, request);
+  const suffix = prefix === ""
+    ? ""
+    : version.major === TailwindcssVersion.V3
+      ? ""
+      : ":";
+
+  return [prefix, suffix];
 }
 
 

--- a/src/tailwind/utils/cache.ts
+++ b/src/tailwind/utils/cache.ts
@@ -1,3 +1,5 @@
+import { env } from "node:process";
+
 import { getModifiedDate } from "../utils/fs.js";
 
 
@@ -9,7 +11,7 @@ export function withCache<Result>(key: string, callback: () => Promise<Result> |
   const modified = getModifiedDate(key);
   const cached = CACHE.get(key);
 
-  if(cached && cached.date > modified){
+  if(env.NODE_ENV !== "test" && cached && cached.date > modified){
     return cached.value;
   }
 

--- a/src/tailwind/v3/prefix.ts
+++ b/src/tailwind/v3/prefix.ts
@@ -1,24 +1,14 @@
 import { findTailwindConfig } from "./config.js";
 import { createTailwindContextFromConfigFile } from "./context.js";
 
-import type { ConfigWarning, GetPrefixRequest, GetPrefixResponse } from "../api/interface.js";
+import type { GetPrefixRequest, GetPrefixResponse } from "../api/interface.js";
 
 
 export async function getPrefix({ configPath, cwd }: GetPrefixRequest): Promise<GetPrefixResponse> {
-  const warnings: ConfigWarning[] = [];
-
   const config = findTailwindConfig(cwd, configPath);
-
-  if(!config){
-    warnings.push({
-      option: "entryPoint",
-      title: `No tailwind css config found at \`${configPath}\``
-    });
-  }
-
   const context = await createTailwindContextFromConfigFile(config);
 
   const prefix = context.tailwindConfig.prefix ?? "";
 
-  return [prefix, warnings];
+  return [prefix, ""];
 }

--- a/src/tailwind/v4/prefix.ts
+++ b/src/tailwind/v4/prefix.ts
@@ -1,24 +1,12 @@
 import { findDefaultConfig, findTailwindConfigPath } from "./config.js";
 import { createTailwindContextFromEntryPoint } from "./context.js";
 
-import type { ConfigWarning, GetPrefixRequest, GetPrefixResponse } from "../api/interface.js";
+import type { GetPrefixRequest, GetPrefixResponse } from "../api/interface.js";
 
 
 export async function getPrefix({ configPath, cwd }: GetPrefixRequest): Promise<GetPrefixResponse> {
-  const warnings: ConfigWarning[] = [];
-
   const config = findTailwindConfigPath(cwd, configPath);
   const defaultConfig = findDefaultConfig(cwd);
-
-  if(!config){
-    warnings.push({
-      option: "entryPoint",
-      title: configPath
-        ? `No tailwind css config found at \`${configPath}\``
-        : "No tailwind css entry point configured"
-    });
-  }
-
   const path = config ?? defaultConfig;
 
   if(!path){
@@ -29,5 +17,5 @@ export async function getPrefix({ configPath, cwd }: GetPrefixRequest): Promise<
 
   const prefix = context.theme.prefix ?? "";
 
-  return [prefix, warnings];
+  return [prefix, ""];
 }


### PR DESCRIPTION
Handles `group` and `peer` classes internally to support [tailwind prefixes](https://tailwindcss.com/docs/styling-with-utility-classes#using-the-prefix-option).

fixes #107