### PR TITLE
feat: no-restricted-classes rule to support custom error messages

### DIFF
--- a/docs/rules/no-restricted-classes.md
+++ b/docs/rules/no-restricted-classes.md
@@ -57,9 +57,9 @@ Disallow the usage of certain classes. This can be useful to disallow classes th
 ## Examples
 
 ```tsx
-// ❌ BAD: disallow the use of the `text-green-500` class with option `{ restrict: [{ pattern: "^(.*)-green-500$", message: "use '$1-success' instead." }] }`
+// ❌ BAD: disallow the use of the `text-green-500` class with option `{ restrict: [{ pattern: "^(.*)-green-500$", message: "Restricted class: Use '$1-success' instead." }] }`
 <div class="text-green-500" />;
-//          ~~~~~~~~~~~~~~ use 'text-success' instead.
+//          ~~~~~~~~~~~~~~ Restricted class: Use 'text-success' instead.
 ```
 
 ```tsx

--- a/docs/rules/no-restricted-classes.md
+++ b/docs/rules/no-restricted-classes.md
@@ -60,6 +60,7 @@ Disallow the usage of certain classes. This can be useful to disallow classes th
 // ❌ BAD: disallow the use of the `text-green-500` class with option `{ restrict: [{ pattern: "^(.*)-green-500$", message: "use '$1-success' instead." }] }`
 <div class="text-green-500" />;
 //          ~~~~~~~~~~~~~~ use 'text-success' instead.
+```
 
 ```tsx
 // ❌ BAD: disallow the use of the child variants with option `{ restrict: ["^\\*+:.*"] }`

--- a/docs/rules/no-restricted-classes.md
+++ b/docs/rules/no-restricted-classes.md
@@ -1,6 +1,6 @@
 # better-tailwindcss/no-restricted-classes
 
-Disallow the usage of certain classes. This can be useful to disallow classes that are not recommended to be used in your project. For example, you can disallow the use of the child variants (`*:`) or the `!important` modifier (`!`) in your project.
+Disallow the usage of certain classes. This can be useful to disallow classes that are not recommended to be used in your project. For example, you can enforce the use of semantic color names or disallow features like child variants (`*:`) or the `!important` modifier (`!`) in your project.
 
 <br/>
 
@@ -8,9 +8,10 @@ Disallow the usage of certain classes. This can be useful to disallow classes th
 
 ### `restrict`
 
-  The classes that should be disallowed. The entries in this list are treated as regular expressions.
+  The classes that should be disallowed. The patterns in this list are treated as regular expressions.
+  Matched groups of the regular expression can be used in the error message by using the `$1`, `$2`, etc. syntax.
 
-  **Type**: `string[]`  
+  **Type**: `string[] | { pattern: string, message?: string }[]`  
   **Default**: `[]`
 
 <br/>
@@ -54,6 +55,11 @@ Disallow the usage of certain classes. This can be useful to disallow classes th
 <br/>
 
 ## Examples
+
+```tsx
+// ❌ BAD: disallow the use of the `text-green-500` class with option `{ restrict: [{ pattern: "^(.*)-green-500$", message: "use '$1-success' instead." }] }`
+<div class="text-green-500" />;
+//          ~~~~~~~~~~~~~~ use 'text-success' instead.
 
 ```tsx
 // ❌ BAD: disallow the use of the child variants with option `{ restrict: ["^\\*+:.*"] }`

--- a/src/rules/no-restricted-classes.test.ts
+++ b/src/rules/no-restricted-classes.test.ts
@@ -105,4 +105,60 @@ describe(noRestrictedClasses.name, () => {
     });
   });
 
+  it("should be possible to provide custom error messages", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold text-green-500 text-lg" />`,
+          html: `<img class="font-bold text-green-500 text-lg" />`,
+          jsx: `() => <img class="font-bold text-green-500 text-lg" />`,
+          svelte: `<img class="font-bold text-green-500 text-lg" />`,
+          vue: `<template><img class="font-bold text-green-500 text-lg" /></template>`,
+
+          errors: [
+            {
+              message: "use '*-success' instead."
+            }
+          ],
+          options: [{ restrict: [{ message: "use '*-success' instead.", pattern: "^(.*)-green-(.*)$" }] }]
+        }
+      ]
+    });
+  });
+
+  it("should be possible to use matched groups in the error messages", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold text-green-500 text-lg" />`,
+          html: `<img class="font-bold text-green-500 text-lg" />`,
+          jsx: `() => <img class="font-bold text-green-500 text-lg" />`,
+          svelte: `<img class="font-bold text-green-500 text-lg" />`,
+          vue: `<template><img class="font-bold text-green-500 text-lg" /></template>`,
+
+          errors: [
+            {
+              message: "use 'text-success' instead."
+            }
+          ],
+          options: [{ restrict: [{ message: "use '$1-success' instead.", pattern: "^(.*)-green-500$" }] }]
+        },
+        {
+          angular: `<img class="font-bold bg-green-500 text-lg" />`,
+          html: `<img class="font-bold bg-green-500 text-lg" />`,
+          jsx: `() => <img class="font-bold bg-green-500 text-lg" />`,
+          svelte: `<img class="font-bold bg-green-500 text-lg" />`,
+          vue: `<template><img class="font-bold bg-green-500 text-lg" /></template>`,
+
+          errors: [
+            {
+              message: "use 'bg-success' instead."
+            }
+          ],
+          options: [{ restrict: [{ message: "use '$1-success' instead.", pattern: "^(.*)-green-500$" }] }]
+        }
+      ]
+    });
+  });
+
 });

--- a/src/rules/no-restricted-classes.test.ts
+++ b/src/rules/no-restricted-classes.test.ts
@@ -117,10 +117,10 @@ describe(noRestrictedClasses.name, () => {
 
           errors: [
             {
-              message: "use '*-success' instead."
+              message: "Restricted class: Use '*-success' instead."
             }
           ],
-          options: [{ restrict: [{ message: "use '*-success' instead.", pattern: "^(.*)-green-(.*)$" }] }]
+          options: [{ restrict: [{ message: "Restricted class: Use '*-success' instead.", pattern: "^(.*)-green-(.*)$" }] }]
         }
       ]
     });
@@ -138,10 +138,10 @@ describe(noRestrictedClasses.name, () => {
 
           errors: [
             {
-              message: "use 'text-success' instead."
+              message: "Restricted class: Use 'text-success' instead."
             }
           ],
-          options: [{ restrict: [{ message: "use '$1-success' instead.", pattern: "^(.*)-green-500$" }] }]
+          options: [{ restrict: [{ message: "Restricted class: Use '$1-success' instead.", pattern: "^(.*)-green-500$" }] }]
         },
         {
           angular: `<img class="font-bold bg-green-500 text-lg" />`,
@@ -152,10 +152,10 @@ describe(noRestrictedClasses.name, () => {
 
           errors: [
             {
-              message: "use 'bg-success' instead."
+              message: "Restricted class: Use 'bg-success' instead."
             }
           ],
-          options: [{ restrict: [{ message: "use '$1-success' instead.", pattern: "^(.*)-green-500$" }] }]
+          options: [{ restrict: [{ message: "Restricted class: Use '$1-success' instead.", pattern: "^(.*)-green-500$" }] }]
         }
       ]
     });

--- a/src/rules/no-restricted-classes.ts
+++ b/src/rules/no-restricted-classes.ts
@@ -135,7 +135,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
           loc: getExactClassLocation(literal, className),
           message: message
             ? replacePlaceholders(message, matches)
-            : "Restricted class: \"{{ restrictedClass }}\"."
+            : "Restricted class: \"{{ className }}\"."
         });
       }
     }

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -43,6 +43,13 @@ export function display(classes: string): string {
     .replaceAll("\t", "→");
 }
 
+export function replacePlaceholders(template: string, match: RegExpMatchArray): string {
+  return template.replace(/\$(\d+)/g, (_, groupIndex) => {
+    const index = Number(groupIndex);
+    return match[index] ?? "";
+  });
+}
+
 export interface Warning<Options extends Record<string, any> = Record<string, any>> {
   option: keyof Options;
   title: string;

--- a/tests/utils/lint.ts
+++ b/tests/utils/lint.ts
@@ -46,7 +46,7 @@ export function lint<Rule extends ESLintRule, Syntaxes extends Record<string, Li
       } & {
         [Key in keyof Syntaxes as `${Key & string}Output`]?: string;
       } & {
-        errors: number;
+        errors: { message: string; type?: string; }[] | number;
       } & {
         files?: Record<string, string>;
         options?: Rule["options"];


### PR DESCRIPTION
```ts
{ 
  restrict: [{ 
    pattern: "^(.*)-green-500$",
    message: "use '$1-success' instead."
  }]
}
```

```tsx
<div class="text-green-500" />;
//          ~~~~~~~~~~~~~~ use 'text-success' instead.
```

fixes: #127 