### PR TITLE
fix: prevent variable matchers from crossing arrow function boundaries

### DIFF
--- a/src/utils/matchers.test.ts
+++ b/src/utils/matchers.test.ts
@@ -352,6 +352,21 @@ describe("matchers", () => {
 
     });
 
+    it("should not cross arrow function boundaries", () => {
+      lint(noUnnecessaryWhitespace, TEST_SYNTAXES, {
+        valid: [
+          {
+            jsx: `const defined = () => " b a ";`,
+            svelte: `<script>const defined = () => " b a ";</script>`,
+            vue: `<script>const defined = () => " b a ";</script>`,
+
+            options: [{
+              variables: [["defined", [{ match: MatcherType.String }]]]
+            }]
+          }
+        ]
+      });
+    });
   });
 
   describe("attributes", () => {

--- a/src/utils/matchers.ts
+++ b/src/utils/matchers.ts
@@ -1,5 +1,6 @@
 import {
   hasESNodeParentExtension,
+  isESArrowFunctionExpression,
   isESCallExpression,
   isESNode,
   isESVariableDeclarator
@@ -44,7 +45,7 @@ export function getLiteralNodesByMatchers<Node>(ctx: Rule.RuleContext, node: unk
 function findMatchingNestedNodes<Node>(
   node: GenericNodeWithParent,
   matcherFunctions: MatcherFunctions<Node>,
-  deadEnd: (node: unknown) => boolean = value => isESNode(value) && (isESCallExpression(value) || isESVariableDeclarator(value))
+  deadEnd: (node: unknown) => boolean = value => isESNode(value) && (isESCallExpression(value) || isESArrowFunctionExpression(value) || isESVariableDeclarator(value))
 ): Node[] {
   return Object.entries(node).reduce<Node[]>((matchedNodes, [key, value]) => {
     if(!value || typeof value !== "object" || key === "parent"){


### PR DESCRIPTION
fixes: #125

```ts
const classes = () => {
 const somethingElse = "no longer getting linted";
}
```