### PR TITLE
fix: improved sorting order with unregistered class with variant

### DIFF
--- a/src/rules/sort-classes.test.ts
+++ b/src/rules/sort-classes.test.ts
@@ -711,4 +711,25 @@ describe(sortClasses.name, () => {
     );
   });
 
+  it("should always put classes without variants first, even if unregistered classes are available", () => {
+    lint(sortClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="hover:unregistered flex hover:text-red-500" />`,
+          angularOutput: `<img class="flex hover:unregistered hover:text-red-500" />`,
+          html: `<img class="hover:unregistered flex hover:text-red-500" />`,
+          htmlOutput: `<img class="flex hover:unregistered hover:text-red-500" />`,
+          jsx: `() => <img class="hover:unregistered flex hover:text-red-500" />`,
+          jsxOutput: `() => <img class="flex hover:unregistered hover:text-red-500" />`,
+          svelte: `<img class="hover:unregistered flex hover:text-red-500" />`,
+          svelteOutput: `<img class="flex hover:unregistered hover:text-red-500" />`,
+          vue: `<template><img class="hover:unregistered flex hover:text-red-500" /></template>`,
+          vueOutput: `<template><img class="flex hover:unregistered hover:text-red-500" /></template>`,
+
+          errors: 1
+        }
+      ]
+    });
+  });
+
 });

--- a/src/rules/sort-classes.ts
+++ b/src/rules/sort-classes.ts
@@ -205,8 +205,13 @@ function sortClassNames(ctx: Rule.RuleContext, classes: string[]): [classes: str
     groupedByVariant.set(variant, [...groupedByVariant.get(variant) ?? [], className]);
   }
 
-  return [Array.from(groupedByVariant.values()).flat(), warnings];
-
+  return [
+    Array.from(groupedByVariant.entries())
+      .sort(([a], [b]) => a === "" ? -1 : b === "" ? 1 : 0)
+      .map(([, classes]) => classes)
+      .flat(),
+    warnings
+  ];
 }
 
 


### PR DESCRIPTION
Fixes the "improved" sorting order, when an unregistered class with a variant was available among classes without variants.

Basically the classes without prefixes should always come first.

```ts
// before
<img class="hover:unregistered flex hover:text-red-500" />
```

```ts
// after
<img class="flex hover:unregistered hover:text-red-500" />
```