### PR TITLE
feat: add autofix to `no-restricted-classes`

### DIFF
--- a/docs/rules/no-restricted-classes.md
+++ b/docs/rules/no-restricted-classes.md
@@ -9,10 +9,22 @@ Disallow the usage of certain classes. This can be useful to disallow classes th
 ### `restrict`
 
   The classes that should be disallowed. The patterns in this list are treated as regular expressions.
-  Matched groups of the regular expression can be used in the error message by using the `$1`, `$2`, etc. syntax.
+  Matched groups of the regular expression can be used in the error message or fix by using the `$1`, `$2`, etc. syntax.
 
-  **Type**: `string[] | { pattern: string, message?: string }[]`  
+  **Type**: `string[] | { pattern: string, message?: string, fix?: string }[]`  
   **Default**: `[]`
+
+  Make sure to match possible variants and modifiers of the class names as well:
+
+  ```json
+  {
+    "restrict": [{
+      "fix": "$1$2-success$3",
+      "message": "Restricted class: Use '$1$2-success$3' instead.",
+      "pattern": "^([a-zA-Z0-9:/_-]*:)?(text|bg)-green-500(\\/[0-9]{1,3})?$"
+    }]
+  }
+  ```
 
 <br/>
 

--- a/docs/rules/no-restricted-classes.md
+++ b/docs/rules/no-restricted-classes.md
@@ -2,6 +2,8 @@
 
 Disallow the usage of certain classes. This can be useful to disallow classes that are not recommended to be used in your project. For example, you can enforce the use of semantic color names or disallow features like child variants (`*:`) or the `!important` modifier (`!`) in your project.
 
+It is also possible to provide a custom error message and a fix for the disallowed class. The fix can be used to automatically replace the disallowed class with a recommended one.
+
 <br/>
 
 ## Options

--- a/src/rules/no-restricted-classes.test.ts
+++ b/src/rules/no-restricted-classes.test.ts
@@ -369,4 +369,33 @@ describe(noRestrictedClasses.name, () => {
     });
   });
 
+  it("should work with mixed string and object restrictions", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="text-green-500 bg-red-500" />`,
+          angularOutput: `<img class="text-success bg-red-500" />`,
+          html: `<img class="text-green-500 bg-red-500" />`,
+          htmlOutput: `<img class="text-success bg-red-500" />`,
+          jsx: `() => <img class="text-green-500 bg-red-500" />`,
+          jsxOutput: `() => <img class="text-success bg-red-500" />`,
+          svelte: `<img class="text-green-500 bg-red-500" />`,
+          svelteOutput: `<img class="text-success bg-red-500" />`,
+          vue: `<template><img class="text-green-500 bg-red-500" /></template>`,
+          vueOutput: `<template><img class="text-success bg-red-500" /></template>`,
+
+          errors: [
+            { message: "Custom message for green" },
+            { message: "Restricted class: \"bg-red-500\"." }
+          ],
+          options: [{
+            restrict: [
+              { fix: "text-success", message: "Custom message for green", pattern: "^text-green-500$" },
+              "^bg-red-500$"
+            ]
+          }]
+        }
+      ]
+    });
+  });
 });

--- a/src/rules/no-restricted-classes.test.ts
+++ b/src/rules/no-restricted-classes.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from "vitest";
 
 import { noRestrictedClasses } from "better-tailwindcss:rules/no-restricted-classes.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
+import { dedent } from "better-tailwindcss:tests/utils/template.js";
 
 
 describe(noRestrictedClasses.name, () => {
@@ -116,9 +117,7 @@ describe(noRestrictedClasses.name, () => {
           vue: `<template><img class="font-bold text-green-500 text-lg" /></template>`,
 
           errors: [
-            {
-              message: "Restricted class: Use '*-success' instead."
-            }
+            { message: "Restricted class: Use '*-success' instead." }
           ],
           options: [{ restrict: [{ message: "Restricted class: Use '*-success' instead.", pattern: "^(.*)-green-(.*)$" }] }]
         }
@@ -137,9 +136,7 @@ describe(noRestrictedClasses.name, () => {
           vue: `<template><img class="font-bold text-green-500 text-lg" /></template>`,
 
           errors: [
-            {
-              message: "Restricted class: Use 'text-success' instead."
-            }
+            { message: "Restricted class: Use 'text-success' instead." }
           ],
           options: [{ restrict: [{ message: "Restricted class: Use '$1-success' instead.", pattern: "^(.*)-green-500$" }] }]
         },
@@ -151,11 +148,222 @@ describe(noRestrictedClasses.name, () => {
           vue: `<template><img class="font-bold bg-green-500 text-lg" /></template>`,
 
           errors: [
-            {
-              message: "Restricted class: Use 'bg-success' instead."
-            }
+            { message: "Restricted class: Use 'bg-success' instead." }
           ],
           options: [{ restrict: [{ message: "Restricted class: Use '$1-success' instead.", pattern: "^(.*)-green-500$" }] }]
+        }
+      ]
+    });
+  });
+
+  it("should fix the classes when a fix is provided", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold bg-green-500 text-green-500 text-lg" />`,
+          angularOutput: `<img class="font-bold bg-success text-success text-lg" />`,
+          html: `<img class="font-bold bg-green-500 text-green-500 text-lg" />`,
+          htmlOutput: `<img class="font-bold bg-success text-success text-lg" />`,
+          jsx: `() => <img class="font-bold bg-green-500 text-green-500 text-lg" />`,
+          jsxOutput: `() => <img class="font-bold bg-success text-success text-lg" />`,
+          svelte: `<img class="font-bold bg-green-500 text-green-500 text-lg" />`,
+          svelteOutput: `<img class="font-bold bg-success text-success text-lg" />`,
+          vue: `<template><img class="font-bold bg-green-500 text-green-500 text-lg" /></template>`,
+          vueOutput: `<template><img class="font-bold bg-success text-success text-lg" /></template>`,
+
+          errors: [
+            { message: "Restricted class: Use 'bg-success' instead." },
+            { message: "Restricted class: Use 'text-success' instead." }
+          ],
+          options: [{
+            restrict: [{
+              fix: "$1-success",
+              message: "Restricted class: Use '$1-success' instead.",
+              pattern: "^(text|bg)-green-500$"
+            }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should fix only the class name when a variant is used", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold lg:text-green-500 text-lg" />`,
+          angularOutput: `<img class="font-bold lg:text-success text-lg" />`,
+          html: `<img class="font-bold lg:text-green-500 text-lg" />`,
+          htmlOutput: `<img class="font-bold lg:text-success text-lg" />`,
+          jsx: `() => <img class="font-bold lg:text-green-500 text-lg" />`,
+          jsxOutput: `() => <img class="font-bold lg:text-success text-lg" />`,
+          svelte: `<img class="font-bold lg:text-green-500 text-lg" />`,
+          svelteOutput: `<img class="font-bold lg:text-success text-lg" />`,
+          vue: `<template><img class="font-bold lg:text-green-500 text-lg" /></template>`,
+          vueOutput: `<template><img class="font-bold lg:text-success text-lg" /></template>`,
+
+          errors: [
+            { message: "Restricted class: Use 'lg:text-success' instead." }
+          ],
+          options: [{
+            restrict: [{
+              fix: "$1$2-success",
+              message: "Restricted class: Use '$1$2-success' instead.",
+              pattern: "^([a-zA-Z0-9:/_-]*:)?(text|bg)-green-500$"
+            }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should fix classes with multiple variants", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold lg:hover:text-green-500 text-lg" />`,
+          angularOutput: `<img class="font-bold lg:hover:text-success text-lg" />`,
+          html: `<img class="font-bold lg:hover:text-green-500 text-lg" />`,
+          htmlOutput: `<img class="font-bold lg:hover:text-success text-lg" />`,
+          jsx: `() => <img class="font-bold lg:hover:text-green-500 text-lg" />`,
+          jsxOutput: `() => <img class="font-bold lg:hover:text-success text-lg" />`,
+          svelte: `<img class="font-bold lg:hover:text-green-500 text-lg" />`,
+          svelteOutput: `<img class="font-bold lg:hover:text-success text-lg" />`,
+          vue: `<template><img class="font-bold lg:hover:text-green-500 text-lg" /></template>`,
+          vueOutput: `<template><img class="font-bold lg:hover:text-success text-lg" /></template>`,
+
+          errors: [
+            { message: "Restricted class: Use 'lg:hover:text-success' instead." }
+          ],
+          options: [{
+            restrict: [{
+              fix: "$1$2-success",
+              message: "Restricted class: Use '$1$2-success' instead.",
+              pattern: "^([a-zA-Z0-9:/_-]*:)?(text|bg)-green-500$"
+            }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should match modifiers", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold lg:hover:text-green-500/50 text-lg" />`,
+          angularOutput: `<img class="font-bold lg:hover:text-success/50 text-lg" />`,
+          html: `<img class="font-bold lg:hover:text-green-500/50 text-lg" />`,
+          htmlOutput: `<img class="font-bold lg:hover:text-success/50 text-lg" />`,
+          jsx: `() => <img class="font-bold lg:hover:text-green-500/50 text-lg" />`,
+          jsxOutput: `() => <img class="font-bold lg:hover:text-success/50 text-lg" />`,
+          svelte: `<img class="font-bold lg:hover:text-green-500/50 text-lg" />`,
+          svelteOutput: `<img class="font-bold lg:hover:text-success/50 text-lg" />`,
+          vue: `<template><img class="font-bold lg:hover:text-green-500/50 text-lg" /></template>`,
+          vueOutput: `<template><img class="font-bold lg:hover:text-success/50 text-lg" /></template>`,
+
+          errors: [
+            { message: "Restricted class: Use 'lg:hover:text-success/50' instead." }
+          ],
+          options: [{
+            restrict: [{
+              fix: "$1$2-success$3",
+              message: "Restricted class: Use '$1$2-success$3' instead.",
+              pattern: "^([a-zA-Z0-9:/_-]*:)?(text|bg)-green-500(\\/[0-9]{1,3})?$"
+            }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should work on multiline literals", () => {
+    const dirty = dedent`
+      bg-green-500
+      hover:text-green-500
+    `;
+
+    const clean = dedent`
+      bg-success
+      hover:text-success
+    `;
+
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="${dirty}" />`,
+          angularOutput: `<img class="${clean}" />`,
+          html: `<img class="${dirty}" />`,
+          htmlOutput: `<img class="${clean}" />`,
+          jsx: `() => <img class="${dirty}" />`,
+          jsxOutput: `() => <img class="${clean}" />`,
+          svelte: `<img class="${dirty}" />`,
+          svelteOutput: `<img class="${clean}" />`,
+          vue: `<template><img class="${dirty}" /></template>`,
+          vueOutput: `<template><img class="${clean}" /></template>`,
+
+          errors: [
+            { message: "Restricted class: Use 'bg-success' instead." },
+            { message: "Restricted class: Use 'hover:text-success' instead." }
+          ],
+          options: [{
+            restrict: [{
+              fix: "$1$2-success",
+              message: "Restricted class: Use '$1$2-success' instead.",
+              pattern: "^([a-zA-Z0-9:/_-]*:)?(text|bg)-green-500$"
+            }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should not report on classes with the same name but different variants", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      valid: [
+        {
+          angular: `<img class="font-bold text-green-500" />`,
+          html: `<img class="font-bold text-green-500" />`,
+          jsx: `() => <img class="font-bold text-green-500" />`,
+          svelte: `<img class="font-bold text-green-500" />`,
+          vue: `<template><img class="font-bold text-green-500" /></template>`,
+
+          options: [{
+            restrict: [{
+              message: "Restricted class: Use 'hover:text-success' instead.",
+              pattern: "^hover:text-green-500$"
+            }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should be possible to remove classes with a fix", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="font-bold text-green-500" />`,
+          angularOutput: `<img class="font-bold " />`,
+          html: `<img class="font-bold text-green-500" />`,
+          htmlOutput: `<img class="font-bold " />`,
+          jsx: `() => <img class="font-bold text-green-500" />`,
+          jsxOutput: `() => <img class="font-bold " />`,
+          svelte: `<img class="font-bold text-green-500" />`,
+          svelteOutput: `<img class="font-bold " />`,
+          vue: `<template><img class="font-bold text-green-500" /></template>`,
+          vueOutput: `<template><img class="font-bold " /></template>`,
+
+          errors: [
+            { message: "Restricted class: text-green-500 is not allowed." }
+          ],
+          options: [{
+            restrict: [{
+              fix: "",
+              message: "Restricted class: text-green-500 is not allowed.",
+              pattern: "^text-green-500$"
+            }]
+          }]
         }
       ]
     });

--- a/src/rules/no-restricted-classes.test.ts
+++ b/src/rules/no-restricted-classes.test.ts
@@ -398,4 +398,127 @@ describe(noRestrictedClasses.name, () => {
       ]
     });
   });
+
+  it("should fallback to empty string for invalid capture groups in messages", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="text-green-500" />`,
+          html: `<img class="text-green-500" />`,
+          jsx: `() => <img class="text-green-500" />`,
+          svelte: `<img class="text-green-500" />`,
+          vue: `<template><img class="text-green-500" /></template>`,
+
+          errors: [
+            { message: "Restricted class: Use '' instead of 'text-green-500'." }
+          ],
+          options: [{
+            restrict: [{
+              message: "Restricted class: Use '$10' instead of '$1'.",
+              pattern: "^(text-green-500)$"
+            }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should fallback to empty string for invalid capture groups in fixes", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="text-green-500" />`,
+          angularOutput: `<img class="" />`,
+          html: `<img class="text-green-500" />`,
+          htmlOutput: `<img class="" />`,
+          jsx: `() => <img class="text-green-500" />`,
+          jsxOutput: `() => <img class="" />`,
+          svelte: `<img class="text-green-500" />`,
+          svelteOutput: `<img class="" />`,
+          vue: `<template><img class="text-green-500" /></template>`,
+          vueOutput: `<template><img class="" /></template>`,
+
+          errors: [
+            { message: "Restricted class: \"text-green-500\"." }
+          ],
+          options: [{
+            restrict: [{
+              fix: "$10",
+              pattern: "^(text-green-500)$"
+            }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should handle multiple overlapping patterns", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="text-green-500" />`,
+          html: `<img class="text-green-500" />`,
+          jsx: `() => <img class="text-green-500" />`,
+          svelte: `<img class="text-green-500" />`,
+          vue: `<template><img class="text-green-500" /></template>`,
+
+          errors: [
+            { message: `Restricted class: "text-green-500".` },
+            { message: "Restricted class: Use 'text-success' instead." },
+            { message: "Match any green color class" }
+          ],
+          options: [{
+            restrict: [
+              "^text-green-500$",
+              { message: "Restricted class: Use 'text-success' instead.", pattern: "^text-green-500$" },
+              { message: "Match any green color class", pattern: ".*green.*" }
+            ]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should work with restriction objects without fix and message", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="text-green-500" />`,
+          html: `<img class="text-green-500" />`,
+          jsx: `() => <img class="text-green-500" />`,
+          svelte: `<img class="text-green-500" />`,
+          vue: `<template><img class="text-green-500" /></template>`,
+
+          errors: [
+            { message: "Restricted class: \"text-green-500\"." }
+          ],
+          options: [{
+            restrict: [{ pattern: "^text-green-500$" }]
+          }]
+        }
+      ]
+    });
+  });
+
+  it("should fallback to the default message when empty", () => {
+    lint(noRestrictedClasses, TEST_SYNTAXES, {
+      invalid: [
+        {
+          angular: `<img class="text-green-500" />`,
+          html: `<img class="text-green-500" />`,
+          jsx: `() => <img class="text-green-500" />`,
+          svelte: `<img class="text-green-500" />`,
+          vue: `<template><img class="text-green-500" /></template>`,
+
+          errors: [
+            { message: "Restricted class: \"text-green-500\"." }
+          ],
+          options: [{
+            restrict: [{ message: "", pattern: "^text-green-500$" }]
+          }]
+        }
+      ]
+    });
+  });
+
 });

--- a/src/rules/no-restricted-classes.ts
+++ b/src/rules/no-restricted-classes.ts
@@ -38,13 +38,11 @@ export type Options = [
     TagOption &
     VariableOption &
     {
-      restrict?:
-        | {
-          pattern: string;
-          fix?: string;
-          message?: string;
-        }[]
-        | string[];
+      restrict?: (string | {
+        pattern: string;
+        fix?: string;
+        message?: string;
+      })[];
     }
   >
 ];


### PR DESCRIPTION
Adds a customizable autofix option to the `no-restricted-classes` rule:

```json
{
  "restrict": [{
    "fix": "$1$2-success$3",
    "message": "Restricted class: Use '$1$2-success$3' instead.",
    "pattern": "^([a-zA-Z0-9:/_-]*:)?(text|bg)-green-500(\\/[0-9]{1,3})?$"
  }]
}
```

```jsx
// before
<img class="font-bold hover:bg-green-500/50 text-green-500 text-lg" />
// after
<img class="font-bold hover:bg-success/50 text-success text-lg" />
```