### PR TITLE
refactor: rename rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 
 | Name | Description | `tw3` | `tw4` | `recommended` | autofix |
 | :--- | :--- | :---: | :---: | :---: | :---: |
-| [multiline](docs/rules/multiline.md) | Enforce consistent line wrapping for tailwind classes. | ✔ | ✔ | ✔ | ✔ |
+| [enforce-consistent-line-wrapping](docs/rules/enforce-consistent-line-wrapping.md) | Enforce consistent line wrapping for tailwind classes. | ✔ | ✔ | ✔ | ✔ |
 | [no-unnecessary-whitespace](docs/rules/no-unnecessary-whitespace.md) | Disallow unnecessary whitespace in tailwind classes. | ✔ | ✔ | ✔ | ✔ |
-| [sort-classes](docs/rules/sort-classes.md) | Enforce a consistent order for tailwind classes. | ✔ | ✔ | ✔ | ✔ |
+| [enforce-consistent-class-order](docs/rules/enforce-consistent-class-order.md) | Enforce a consistent order for tailwind classes. | ✔ | ✔ | ✔ | ✔ |
 | [no-duplicate-classes](docs/rules/no-duplicate-classes.md) | Remove duplicate classes. | ✔ | ✔ | ✔ | ✔ |
 | [enforce-consistent-variable-syntax](docs/rules/enforce-consistent-variable-syntax.md) | Enforce consistent variable syntax. | ✔ | ✔ |  | ✔ |
 

--- a/docs/api/defaults.md
+++ b/docs/api/defaults.md
@@ -26,7 +26,19 @@ export default [
       "better-tailwindcss": eslintPluginBetterTailwindcss
     },
     rules: {
-      "better-tailwindcss/multiline": ["warn", {
+      "better-tailwindcss/enforce-consistent-class-order": ["warn", {
+        attributes: [
+          ...getDefaultTags(),
+          [
+            "myTag", [
+              {
+                match: MatcherType.String
+              }
+            ]
+          ]
+        ]
+      }],
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", {
         callees: [
           ...getDefaultCallees(),
           [
@@ -55,18 +67,6 @@ export default [
           ...getDefaultVariables(),
           [
             "myVariable", [
-              {
-                match: MatcherType.String
-              }
-            ]
-          ]
-        ]
-      }],
-      "better-tailwindcss/sort-classes": ["warn", {
-        attributes: [
-          ...getDefaultTags(),
-          [
-            "myTag", [
               {
                 match: MatcherType.String
               }

--- a/docs/parsers/angular.md
+++ b/docs/parsers/angular.md
@@ -51,7 +51,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -84,7 +84,7 @@ export default [
       "plugins": ["better-tailwindcss"],
       "rules": {
         // or configure rules individually
-        "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+        "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
       }
     }
   ]

--- a/docs/parsers/astro.md
+++ b/docs/parsers/astro.md
@@ -40,7 +40,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -65,7 +65,7 @@ export default [
   "plugins": ["better-tailwindcss"],
   "rules": {
     // or configure rules individually
-    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+    "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
   }
 }
 ```

--- a/docs/parsers/html.md
+++ b/docs/parsers/html.md
@@ -39,7 +39,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -62,7 +62,7 @@ export default [
   "plugins": ["better-tailwindcss"],
   "rules": {
     // or configure rules individually
-    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+    "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
   }
 }
 ```

--- a/docs/parsers/javascript.md
+++ b/docs/parsers/javascript.md
@@ -28,7 +28,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -50,7 +50,7 @@ export default [
   "plugins": ["better-tailwindcss"],
   "rules": {
     // or configure rules individually
-    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+    "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
   }
 }
 ```

--- a/docs/parsers/jsx.md
+++ b/docs/parsers/jsx.md
@@ -35,7 +35,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -63,7 +63,7 @@ export default [
   "plugins": ["better-tailwindcss"],
   "rules": {
     // or configure rules individually
-    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+    "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
   }
 }
 ```

--- a/docs/parsers/svelte.md
+++ b/docs/parsers/svelte.md
@@ -39,7 +39,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -62,7 +62,7 @@ export default [
   "plugins": ["better-tailwindcss"],
   "rules": {
     // or configure rules individually
-    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+    "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
   }
 }
 ```

--- a/docs/parsers/tsx.md
+++ b/docs/parsers/tsx.md
@@ -52,7 +52,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -81,7 +81,7 @@ export default [
   "plugins": ["better-tailwindcss"],
   "rules": {
     // or configure rules individually
-    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+    "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
   }
 }
 ```

--- a/docs/parsers/typescript.md
+++ b/docs/parsers/typescript.md
@@ -42,7 +42,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -65,7 +65,7 @@ export default [
   "plugins": ["better-tailwindcss"],
   "rules": {
     // or configure rules individually
-    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+    "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
   }
 }
 ```

--- a/docs/parsers/vue.md
+++ b/docs/parsers/vue.md
@@ -39,7 +39,7 @@ export default [
       ...eslintPluginBetterTailwindcss.configs["recommended-error"].rules,
 
       // or configure rules individually
-      "better-tailwindcss/multiline": ["warn", { printWidth: 100 }]
+      "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { printWidth: 100 }]
     }
   }
 ];
@@ -62,7 +62,7 @@ export default [
   "plugins": ["better-tailwindcss"],
   "rules": {
     // or configure rules individually
-    "better-tailwindcss/multiline": ["warn", { "printWidth": 100 }]
+    "better-tailwindcss/enforce-consistent-line-wrapping": ["warn", { "printWidth": 100 }]
   }
 }
 ```

--- a/docs/rules/enforce-consistent-class-order.md
+++ b/docs/rules/enforce-consistent-class-order.md
@@ -1,4 +1,4 @@
-# better-tailwindcss/sort-classes
+# better-tailwindcss/enforce-consistent-class-order
 
 Enforce the order of tailwind classes. It is possible to sort classes alphabetically or logically.
 

--- a/docs/rules/enforce-consistent-line-wrapping.md
+++ b/docs/rules/enforce-consistent-line-wrapping.md
@@ -1,4 +1,4 @@
-# better-tailwindcss/multiline
+# better-tailwindcss/enforce-consistent-line-wrapping
 
 Enforce tailwind classes to be broken up into multiple lines. It is possible to break at a certain print width or a certain number of classes per line.
 

--- a/docs/rules/no-unnecessary-whitespace.md
+++ b/docs/rules/no-unnecessary-whitespace.md
@@ -9,7 +9,7 @@ Disallow unnecessary whitespace in between and around tailwind classes.
 ### `allowMultiline`
 
   Allow multi-line class declarations.  
-  If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [better-tailwindcss/multiline](./multiline.md).  
+  If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [better-tailwindcss/enforce-consistent-line-wrapping](./enforce-consistent-line-wrapping.md).  
   
   **Type**: `boolean`  
   **Default**: `true`

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.4.0",
+  "version": "3.3.1",
   "type": "module",
   "name": "eslint-plugin-better-tailwindcss",
   "description": "auto-wraps tailwind classes after a certain print width or class count into multiple lines to improve readability.",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.3.1",
+  "version": "3.4.0",
   "type": "module",
   "name": "eslint-plugin-better-tailwindcss",
   "description": "auto-wraps tailwind classes after a certain print width or class count into multiple lines to improve readability.",

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -38,7 +38,6 @@ const getStylisticRules = (severity: "error" | "warn" = "warn") => {
   return {
     [`${plugin.meta.name}/${enforceConsistentClassOrder.name}`]: severity,
     [`${plugin.meta.name}/${enforceConsistentLineWrapping.name}`]: severity,
-    [`${plugin.meta.name}/${enforceConsistentLineWrapping.name}`]: severity,
     [`${plugin.meta.name}/${noDuplicateClasses.name}`]: severity,
     [`${plugin.meta.name}/${noUnnecessaryWhitespace.name}`]: severity
   };

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -1,11 +1,13 @@
+import { multiline } from "better-tailwindcss:rules/deprecated/multiline.js";
+import { sortClasses } from "better-tailwindcss:rules/deprecated/sort-classes.js";
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
+import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
 import { enforceConsistentVariableSyntax } from "better-tailwindcss:rules/enforce-consistent-variable-syntax.js";
-import { multiline } from "better-tailwindcss:rules/multiline.js";
 import { noConflictingClasses } from "better-tailwindcss:rules/no-conflicting-classes.js";
 import { noDuplicateClasses } from "better-tailwindcss:rules/no-duplicate-classes.js";
 import { noRestrictedClasses } from "better-tailwindcss:rules/no-restricted-classes.js";
 import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
 import { noUnregisteredClasses } from "better-tailwindcss:rules/no-unregistered-classes.js";
-import { sortClasses } from "better-tailwindcss:rules/sort-classes.js";
 
 import type { ESLint } from "eslint";
 
@@ -15,14 +17,17 @@ const plugin = {
     name: "better-tailwindcss"
   },
   rules: {
-    [enforceConsistentVariableSyntax.name]: enforceConsistentVariableSyntax.rule,
     [multiline.name]: multiline.rule,
+    [sortClasses.name]: sortClasses.rule,
+
+    [enforceConsistentClassOrder.name]: enforceConsistentClassOrder.rule,
+    [enforceConsistentLineWrapping.name]: enforceConsistentLineWrapping.rule,
+    [enforceConsistentVariableSyntax.name]: enforceConsistentVariableSyntax.rule,
     [noConflictingClasses.name]: noConflictingClasses.rule,
     [noDuplicateClasses.name]: noDuplicateClasses.rule,
     [noRestrictedClasses.name]: noRestrictedClasses.rule,
     [noUnnecessaryWhitespace.name]: noUnnecessaryWhitespace.rule,
-    [noUnregisteredClasses.name]: noUnregisteredClasses.rule,
-    [sortClasses.name]: sortClasses.rule
+    [noUnregisteredClasses.name]: noUnregisteredClasses.rule
   }
 } satisfies ESLint.Plugin;
 
@@ -31,10 +36,11 @@ const plugins = [plugin.meta.name];
 
 const getStylisticRules = (severity: "error" | "warn" = "warn") => {
   return {
-    [`${plugin.meta.name}/${multiline.name}`]: severity,
+    [`${plugin.meta.name}/${enforceConsistentClassOrder.name}`]: severity,
+    [`${plugin.meta.name}/${enforceConsistentLineWrapping.name}`]: severity,
+    [`${plugin.meta.name}/${enforceConsistentLineWrapping.name}`]: severity,
     [`${plugin.meta.name}/${noDuplicateClasses.name}`]: severity,
-    [`${plugin.meta.name}/${noUnnecessaryWhitespace.name}`]: severity,
-    [`${plugin.meta.name}/${sortClasses.name}`]: severity
+    [`${plugin.meta.name}/${noUnnecessaryWhitespace.name}`]: severity
   };
 };
 

--- a/src/parsers/angular.test.ts
+++ b/src/parsers/angular.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from "vitest";
 
-import { sortClasses } from "better-tailwindcss:rules/sort-classes.js";
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { dedent } from "better-tailwindcss:tests/utils/template.js";
 import { MatcherType } from "better-tailwindcss:types/rule.js";
@@ -10,7 +10,7 @@ describe("angular", () => {
 
   describe("defaults", () => {
     it("should support normal classes", () => {
-      lint(sortClasses, TEST_SYNTAXES, {
+      lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
         invalid: [
           {
             angular: `<img class="b a" />`,
@@ -38,7 +38,7 @@ describe("angular", () => {
     });
 
     it("should support array binding in [class] and [ngClass]", () => {
-      lint(sortClasses, TEST_SYNTAXES, {
+      lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
         invalid: [
           {
             angular: `<img [class]="['b a', 'd c']" />`,
@@ -59,7 +59,7 @@ describe("angular", () => {
     });
 
     it("should support expressions in literal arrays", () => {
-      lint(sortClasses, TEST_SYNTAXES, {
+      lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
         invalid: [
           {
             angular: `<img [class]="['b a', expression ? 'd c' : 'f e']" />`,
@@ -80,7 +80,7 @@ describe("angular", () => {
     });
 
     it("should support object keys in [class] and [ngClass]", () => {
-      lint(sortClasses, TEST_SYNTAXES, {
+      lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
         invalid: [
           {
             angular: `<img [class]="{ 'b a': true, 'd c': false }" />`,
@@ -103,7 +103,7 @@ describe("angular", () => {
 
   describe("names", () => {
     it("should match attribute names via names regex", () => {
-      lint(sortClasses, TEST_SYNTAXES, {
+      lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
         invalid: [
           {
             angular: `<img customAttribute="b a" />`,
@@ -142,7 +142,7 @@ describe("angular", () => {
 
     describe("string", () => {
       it("should match attribute names via matchers", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: `<img class="b a" />`,
@@ -172,7 +172,7 @@ describe("angular", () => {
 
     describe("object keys", () => {
       it("should match object keys", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: `<img [class]="{ 'b a': true, 'd c': false }" />`,
@@ -215,7 +215,7 @@ describe("angular", () => {
       });
 
       it("should still match the object key when there is a value with the same content", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: `<img [class]="{ 'b a': 'd c', 'd c': 'b a' }" />`,
@@ -261,7 +261,7 @@ describe("angular", () => {
     describe("object values", () => {
       // this is not used by angular, but matchers should still be able to handle it
       it("should support object values", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: `<img [ngClass]="{ '0': 'b a', '1': 'd c' }" />`,
@@ -284,7 +284,7 @@ describe("angular", () => {
 
     describe("arrays", () => {
       it("should support arrays", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: `<img [class]="['b a', 'd c']" />`,
@@ -305,7 +305,7 @@ describe("angular", () => {
       });
 
       it("should support expressions in arrays", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: `<img [class]="['b a', expression ? 'd c' : 'f e']" />`,
@@ -328,7 +328,7 @@ describe("angular", () => {
 
     describe("expressions", () => {
       it("should lint classes returned from expressions", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: `<img class="{{ true === 'b a' ? 'b a' : 'd c' }}" />`,
@@ -358,7 +358,7 @@ describe("angular", () => {
 
     describe("template literals", () => {
       it("should support template literals in interpolated class", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             // 1st pass of multi pass fix
             {
@@ -382,7 +382,7 @@ describe("angular", () => {
       });
 
       it("should support short circuiting", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: "<img [class]=\"`${'b a' && 'd c'}`\" />",
@@ -403,7 +403,7 @@ describe("angular", () => {
       });
 
       it("should lint classes around expressions", () => {
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
           // 1st pass of multi pass fix
             {
@@ -454,7 +454,7 @@ describe("angular", () => {
           c d
         `;
 
-        lint(sortClasses, TEST_SYNTAXES, {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               angular: `<img [class]="\`${dirty}\`" />`,

--- a/src/parsers/html.test.ts
+++ b/src/parsers/html.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from "vitest";
 
-import { sortClasses } from "better-tailwindcss:rules/sort-classes.js";
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 
 
 describe("html", () => {
 
   it("should match attribute names via regex", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           html: `<img customAttribute="b a" />`,

--- a/src/parsers/jsx.test.ts
+++ b/src/parsers/jsx.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "vitest";
 
-import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
 import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
+import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 
 

--- a/src/parsers/jsx.test.ts
+++ b/src/parsers/jsx.test.ts
@@ -1,13 +1,13 @@
 import { describe, it } from "vitest";
 
 import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
-import { sortClasses } from "better-tailwindcss:rules/sort-classes.js";
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 
 
 describe("jsx", () => {
   it("should match attribute names via regex", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           jsx: `<img customAttribute="b a" />`,
@@ -33,7 +33,7 @@ describe("jsx", () => {
 
 describe("astro (jsx)", () => {
   it("should match astro syntactic sugar", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           astro: `<img class:list="b a" />`,

--- a/src/parsers/svelte.test.ts
+++ b/src/parsers/svelte.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "vitest";
 
-import { multiline } from "better-tailwindcss:rules/multiline.js";
+import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
 import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
-import { sortClasses } from "better-tailwindcss:rules/sort-classes.js";
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { dedent } from "better-tailwindcss:tests/utils/template.js";
 
@@ -10,7 +10,7 @@ import { dedent } from "better-tailwindcss:tests/utils/template.js";
 describe("svelte", () => {
 
   it("should match attribute names via regex", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           svelte: `<img customAttribute="b a" />`,
@@ -25,7 +25,7 @@ describe("svelte", () => {
 
   // #42
   it("should work with shorthand attributes", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           svelte: `<script>let disabled = true;</script><img class="c b a" {disabled} />`,
@@ -45,7 +45,7 @@ describe("svelte", () => {
       d e f
     `;
 
-    lint(multiline, TEST_SYNTAXES, {
+    lint(enforceConsistentLineWrapping, TEST_SYNTAXES, {
       invalid: [
         {
           svelte: `<img class={true ? '${singleLine}' : '${singleLine}'} />`,

--- a/src/parsers/svelte.test.ts
+++ b/src/parsers/svelte.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "vitest";
 
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
 import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
-import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { dedent } from "better-tailwindcss:tests/utils/template.js";
 

--- a/src/parsers/vue.test.ts
+++ b/src/parsers/vue.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "vitest";
 
-import { multiline } from "better-tailwindcss:rules/multiline.js";
+import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
 import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
-import { sortClasses } from "better-tailwindcss:rules/sort-classes.js";
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { dedent } from "better-tailwindcss:tests/utils/template.js";
 import { MatcherType } from "better-tailwindcss:types/rule.js";
@@ -11,7 +11,7 @@ import { MatcherType } from "better-tailwindcss:types/rule.js";
 describe("vue", () => {
 
   it("should match attribute names via regex", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           vue: `<template><img customAttribute="b a" /></template>`,
@@ -25,7 +25,7 @@ describe("vue", () => {
   });
 
   it("should work in objects in bound classes", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           vue: `<template><img v-bind:class="{ 'c b a': condition === 'c b a' }" /></template>`,
@@ -46,7 +46,7 @@ describe("vue", () => {
   });
 
   it("should work in arrays in bound classes", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           vue: `<template><img v-bind:class="[condition === 'c b a' ? 'c b a' : 'f e d']" /></template>`,
@@ -67,7 +67,7 @@ describe("vue", () => {
   });
 
   it("should evaluate bound classes", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           vue: `<template><img v-bind:class="defined('c b a')" /></template>`,
@@ -88,7 +88,7 @@ describe("vue", () => {
   });
 
   it("should automatically prefix bound classes", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           vue: `<template><img v-bind:custom-class="['c b a']" /></template>`,
@@ -109,7 +109,7 @@ describe("vue", () => {
   });
 
   it("should match bound classes via regex", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           vue: `<template><img v-bind:testStyles="['c b a']" /></template>`,
@@ -130,7 +130,7 @@ describe("vue", () => {
       d e f
     `;
 
-    lint(multiline, TEST_SYNTAXES, {
+    lint(enforceConsistentLineWrapping, TEST_SYNTAXES, {
       invalid: [
         {
           vue: `<template><img :class="[true ? '${singleLine}' : '${singleLine}']" /></template>`,

--- a/src/parsers/vue.test.ts
+++ b/src/parsers/vue.test.ts
@@ -1,8 +1,8 @@
 import { describe, it } from "vitest";
 
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
 import { noUnnecessaryWhitespace } from "better-tailwindcss:rules/no-unnecessary-whitespace.js";
-import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { dedent } from "better-tailwindcss:tests/utils/template.js";
 import { MatcherType } from "better-tailwindcss:types/rule.js";

--- a/src/rules/deprecated/multiline.ts
+++ b/src/rules/deprecated/multiline.ts
@@ -1,0 +1,27 @@
+import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
+
+import type { ESLintRule } from "better-tailwindcss:types/rule.js";
+
+
+export const multiline: ESLintRule = {
+  ...enforceConsistentLineWrapping,
+  name: "multiline" as const,
+  rule: {
+    ...enforceConsistentLineWrapping.rule,
+    meta: {
+      ...enforceConsistentLineWrapping.rule.meta,
+      deprecated: {
+        availableUntil: "^4.0.0",
+        deprecatedSince: "^3.4.0",
+        replacedBy: [
+          {
+            message: "The rule name `multiline` is deprecated. Please use `enforce-consistent-line-wrapping` instead.",
+            rule: {
+              name: "enforce-consistent-line-wrapping"
+            }
+          }
+        ]
+      }
+    }
+  }
+};

--- a/src/rules/deprecated/sort-classes.ts
+++ b/src/rules/deprecated/sort-classes.ts
@@ -1,0 +1,26 @@
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
+
+import type { ESLintRule } from "better-tailwindcss:types/rule.js";
+
+
+export const sortClasses: ESLintRule = {
+  name: "sort-classes" as const,
+  rule: {
+    ...enforceConsistentClassOrder.rule,
+    meta: {
+      ...enforceConsistentClassOrder.rule.meta,
+      deprecated: {
+        availableUntil: "^4.0.0",
+        deprecatedSince: "^3.4.0",
+        replacedBy: [
+          {
+            message: "The rule name `sort-classes` is deprecated. Please use `enforce-consistent-class-order` instead.",
+            rule: {
+              name: "enforce-consistent-class-order"
+            }
+          }
+        ]
+      }
+    }
+  }
+};

--- a/src/rules/enforce-consistent-class-order.test.ts
+++ b/src/rules/enforce-consistent-class-order.test.ts
@@ -1,14 +1,14 @@
 import { describe, it } from "vitest";
 
-import { sortClasses } from "better-tailwindcss:rules/sort-classes.js";
+import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 
 
-describe(sortClasses.name, () => {
+describe(enforceConsistentClassOrder.name, () => {
 
   it("should sort simple class names in string literals by the defined order", () => {
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -92,7 +92,7 @@ describe(sortClasses.name, () => {
   });
 
   it("should group all classes with the same variant together", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           angular: `<img class="hover:text-black focus:text-black dark:text-black focus:text-white hover:text-white dark:text-white" />`,
@@ -115,7 +115,7 @@ describe(sortClasses.name, () => {
 
   it("should keep the quotes as they are", () => {
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -178,7 +178,7 @@ describe(sortClasses.name, () => {
   });
 
   it("should keep expressions as they are", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       valid: [
         {
           jsx: `() => <img class={true ? "b a" : "c b"} />`,
@@ -189,7 +189,7 @@ describe(sortClasses.name, () => {
   });
 
   it("should keep expressions where they are", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           jsx: `() => <img class={\`c a \${true ? "e" : "f"} d b \`} />`,
@@ -217,7 +217,7 @@ describe(sortClasses.name, () => {
     const dirty = `c b a${expression}f e d`;
     const clean = `b c a${expression}f d e`;
 
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           jsx: `() => <img class={\`${dirty}\`} />`,
@@ -244,7 +244,7 @@ describe(sortClasses.name, () => {
     `;
 
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -319,7 +319,7 @@ describe(sortClasses.name, () => {
     const dirtyUndefined = "notDefined(\"b a d c\");";
 
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -348,7 +348,7 @@ describe(sortClasses.name, () => {
     );
 
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -422,7 +422,7 @@ describe(sortClasses.name, () => {
     );`;
 
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -483,7 +483,7 @@ describe(sortClasses.name, () => {
     `;
 
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -528,7 +528,7 @@ describe(sortClasses.name, () => {
     \`;`;
 
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -604,7 +604,7 @@ describe(sortClasses.name, () => {
     \`;`;
 
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -682,7 +682,7 @@ describe(sortClasses.name, () => {
 
   it("should sort simple class names in tagged template literals", () => {
     lint(
-      sortClasses,
+      enforceConsistentClassOrder,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -712,7 +712,7 @@ describe(sortClasses.name, () => {
   });
 
   it("should always put classes without variants first, even if unregistered classes are available", () => {
-    lint(sortClasses, TEST_SYNTAXES, {
+    lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
       invalid: [
         {
           angular: `<img class="hover:unregistered flex hover:text-red-500" />`,

--- a/src/rules/enforce-consistent-class-order.ts
+++ b/src/rules/enforce-consistent-class-order.ts
@@ -58,10 +58,10 @@ const defaultOptions = {
   variables: DEFAULT_VARIABLE_NAMES
 } as const satisfies Options[0];
 
-const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/sort-classes.md";
+const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/enforce-consistent-class-order.md";
 
-export const sortClasses: ESLintRule<Options> = {
-  name: "sort-classes" as const,
+export const enforceConsistentClassOrder: ESLintRule<Options> = {
+  name: "enforce-consistent-class-order" as const,
   rule: {
     create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
     meta: {

--- a/src/rules/enforce-consistent-line-wrapping.test.ts
+++ b/src/rules/enforce-consistent-line-wrapping.test.ts
@@ -1,17 +1,17 @@
 import { getTailwindcssVersion, TailwindcssVersion } from "src/async-utils/version.js";
 import { describe, it } from "vitest";
 
-import { multiline } from "better-tailwindcss:rules/multiline.js";
+import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { css, dedent, ts } from "better-tailwindcss:tests/utils/template.js";
 import { MatcherType } from "better-tailwindcss:types/rule.js";
 
 
-describe(multiline.name, () => {
+describe(enforceConsistentLineWrapping.name, () => {
 
   it("should not wrap empty strings", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         valid: [
@@ -48,7 +48,7 @@ describe(multiline.name, () => {
 
   it("should not wrap short lines", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         valid: [
@@ -92,7 +92,7 @@ describe(multiline.name, () => {
     const clean = "a b";
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -118,7 +118,7 @@ describe(multiline.name, () => {
 
   it("should not clean up whitespace in single line strings", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         valid: [
@@ -150,7 +150,7 @@ describe(multiline.name, () => {
     `;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -179,7 +179,7 @@ describe(multiline.name, () => {
     `;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -211,7 +211,7 @@ describe(multiline.name, () => {
     `;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -237,7 +237,7 @@ describe(multiline.name, () => {
 
   it("should disable the `printWidth` limit when set to `0`", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         valid: [
@@ -268,7 +268,7 @@ describe(multiline.name, () => {
     const dirtyUndefined = "notDefined('a b c d e f g h')";
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -294,7 +294,7 @@ describe(multiline.name, () => {
     );
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -334,7 +334,7 @@ describe(multiline.name, () => {
     const dirtyUndefined = `const notDefined = "a b c d e f g h"`;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -367,7 +367,7 @@ describe(multiline.name, () => {
     const cleanConditionalExpression = `true ? \`\n  1 2 3\n  4 5 6\n  7 8\n\` : \`\n  9 10 11\n  12 13 14\n  15 16\n\``;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -392,7 +392,7 @@ describe(multiline.name, () => {
     const cleanLogicalExpression = `true && \`\n  1 2 3\n  4 5 6\n  7 8\n\``;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -417,7 +417,7 @@ describe(multiline.name, () => {
     const cleanArray = `[\`\n  1 2 3\n  4 5 6\n  7 8\n\`, \`\n  9 10 11\n  12 13 14\n  15 16\n\`]`;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -493,7 +493,7 @@ describe(multiline.name, () => {
     );`;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -537,7 +537,7 @@ describe(multiline.name, () => {
     `;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -609,7 +609,7 @@ describe(multiline.name, () => {
       g h
     `;
 
-    lint(multiline, TEST_SYNTAXES, {
+    lint(enforceConsistentLineWrapping, TEST_SYNTAXES, {
       invalid: [
         {
           angular: `<img class="${singleLine}" />`,
@@ -709,7 +709,7 @@ describe(multiline.name, () => {
     `;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -792,7 +792,7 @@ describe(multiline.name, () => {
     `;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -847,7 +847,7 @@ describe(multiline.name, () => {
     `;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         valid: [
@@ -874,7 +874,7 @@ describe(multiline.name, () => {
     \`;`;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -940,7 +940,7 @@ describe(multiline.name, () => {
     };`;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1012,7 +1012,7 @@ describe(multiline.name, () => {
     };`;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1045,7 +1045,7 @@ describe(multiline.name, () => {
     const clean = "\r\n  a b c\r\n  d e f\r\n  g h\r\n";
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1076,7 +1076,7 @@ describe(multiline.name, () => {
     const clean = "\n\ta b c\n\td e f\n\tg h\n";
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1112,7 +1112,7 @@ describe(multiline.name, () => {
     `;
 
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         valid: [
@@ -1130,7 +1130,7 @@ describe(multiline.name, () => {
 
   it("should be possible to change group separation by emptyLines", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1156,7 +1156,7 @@ describe(multiline.name, () => {
 
   it("should be possible to change group separation to emptyLine", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1182,7 +1182,7 @@ describe(multiline.name, () => {
 
   it("should be wrap groups according to preferSingleLine", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1235,7 +1235,7 @@ describe(multiline.name, () => {
 
   it("should remove duplicate classes in string literals in defined tagged template literals", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1275,7 +1275,7 @@ describe(multiline.name, () => {
 
   it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should ignore prefixed variants in tailwind <= 3", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [
@@ -1310,7 +1310,7 @@ describe(multiline.name, () => {
 
   it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should ignore prefixed variants in tailwind >= 4", () => {
     lint(
-      multiline,
+      enforceConsistentLineWrapping,
       TEST_SYNTAXES,
       {
         invalid: [

--- a/src/rules/enforce-consistent-line-wrapping.ts
+++ b/src/rules/enforce-consistent-line-wrapping.ts
@@ -69,8 +69,8 @@ const defaultOptions = {
 
 const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/multiline.md";
 
-export const multiline: ESLintRule<Options> = {
-  name: "multiline" as const,
+export const enforceConsistentLineWrapping: ESLintRule<Options> = {
+  name: "enforce-consistent-line-wrapping" as const,
   rule: {
     create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
     meta: {

--- a/src/rules/no-unnecessary-whitespace.ts
+++ b/src/rules/no-unnecessary-whitespace.ts
@@ -67,7 +67,7 @@ export const noUnnecessaryWhitespace: ESLintRule<Options> = {
           properties: {
             allowMultiline: {
               default: defaultOptions.allowMultiline,
-              description: "Allow multi-line class declarations. If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [better-tailwindcss/multiline](./multiline.md).",
+              description: "Allow multi-line class declarations. If this option is disabled, template literal strings will be collapsed into a single line string wherever possible. Must be set to `true` when used in combination with [better-tailwindcss/enforce-consistent-line-wrapping](./enforce-consistent-line-wrapping.md).",
               type: "boolean"
             },
             ...CALLEE_SCHEMA,

--- a/tests/e2e/commonjs/test.test.ts
+++ b/tests/e2e/commonjs/test.test.ts
@@ -20,9 +20,9 @@ describe("e2e/commonjs", async () => {
     expect(json.warningCount).toBe(4);
 
     expect(json.messages.map(({ ruleId }) => ruleId)).toEqual([
+      "better-tailwindcss/enforce-consistent-class-order",
       "better-tailwindcss/enforce-consistent-line-wrapping",
       "better-tailwindcss/no-unnecessary-whitespace",
-      "better-tailwindcss/enforce-consistent-class-order",
       "better-tailwindcss/no-duplicate-classes"
     ]);
 

--- a/tests/e2e/commonjs/test.test.ts
+++ b/tests/e2e/commonjs/test.test.ts
@@ -20,9 +20,9 @@ describe("e2e/commonjs", async () => {
     expect(json.warningCount).toBe(4);
 
     expect(json.messages.map(({ ruleId }) => ruleId)).toEqual([
-      "better-tailwindcss/multiline",
+      "better-tailwindcss/enforce-consistent-line-wrapping",
       "better-tailwindcss/no-unnecessary-whitespace",
-      "better-tailwindcss/sort-classes",
+      "better-tailwindcss/enforce-consistent-class-order",
       "better-tailwindcss/no-duplicate-classes"
     ]);
 

--- a/tests/e2e/esm/test.test.ts
+++ b/tests/e2e/esm/test.test.ts
@@ -20,9 +20,9 @@ describe("e2e/esm", async () => {
     expect(json.warningCount).toBe(4);
 
     expect(json.messages.map(({ ruleId }) => ruleId)).toEqual([
+      "better-tailwindcss/enforce-consistent-class-order",
       "better-tailwindcss/enforce-consistent-line-wrapping",
       "better-tailwindcss/no-unnecessary-whitespace",
-      "better-tailwindcss/enforce-consistent-class-order",
       "better-tailwindcss/no-duplicate-classes"
     ]);
 

--- a/tests/e2e/esm/test.test.ts
+++ b/tests/e2e/esm/test.test.ts
@@ -20,9 +20,9 @@ describe("e2e/esm", async () => {
     expect(json.warningCount).toBe(4);
 
     expect(json.messages.map(({ ruleId }) => ruleId)).toEqual([
-      "better-tailwindcss/multiline",
+      "better-tailwindcss/enforce-consistent-line-wrapping",
       "better-tailwindcss/no-unnecessary-whitespace",
-      "better-tailwindcss/sort-classes",
+      "better-tailwindcss/enforce-consistent-class-order",
       "better-tailwindcss/no-duplicate-classes"
     ]);
 


### PR DESCRIPTION
Rename rules to be more consistent

- better-tailwindcss/multiline -> better-tailwindcss/enforce-consistent-line-wrapping
- better-tailwindcss/sort-classes -> better-tailwindcss/enforce-consistent-class-order

The old rule names have been deprecated and will be removed with v4.0.0.