### PR TITLE
feat: enforce shorthand classes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,6 +16,7 @@
     "classnames",
     "clsx",
     "cnbuilder",
+    "csstree",
     "dcnb",
     "DCNB",
     "Declarators",
@@ -26,13 +27,13 @@
     "jiti",
     "linebreak",
     "linebreakstyle",
+    "longhands",
     "memfs",
     "objstr",
     "OBJSTR",
     "quasis",
     "shadcn",
     "synckit",
-    "Tmpl",
-    "csstree"
+    "Tmpl"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -148,10 +148,11 @@ The table below lists all available rules, the Tailwind CSS versions they suppor
 | Name | Description | `tw3` | `tw4` | `recommended` | autofix |
 | :--- | :--- | :---: | :---: | :---: | :---: |
 | [enforce-consistent-line-wrapping](docs/rules/enforce-consistent-line-wrapping.md) | Enforce consistent line wrapping for tailwind classes. | ✔ | ✔ | ✔ | ✔ |
-| [no-unnecessary-whitespace](docs/rules/no-unnecessary-whitespace.md) | Disallow unnecessary whitespace in tailwind classes. | ✔ | ✔ | ✔ | ✔ |
 | [enforce-consistent-class-order](docs/rules/enforce-consistent-class-order.md) | Enforce a consistent order for tailwind classes. | ✔ | ✔ | ✔ | ✔ |
-| [no-duplicate-classes](docs/rules/no-duplicate-classes.md) | Remove duplicate classes. | ✔ | ✔ | ✔ | ✔ |
 | [enforce-consistent-variable-syntax](docs/rules/enforce-consistent-variable-syntax.md) | Enforce consistent variable syntax. | ✔ | ✔ |  | ✔ |
+| [enforce-shorthand-classes](docs/rules/enforce-shorthand-classes.md) | Enforce shorthand class names. | ✔ | ✔ |  | ✔ |
+| [no-duplicate-classes](docs/rules/no-duplicate-classes.md) | Remove duplicate classes. | ✔ | ✔ | ✔ | ✔ |
+| [no-unnecessary-whitespace](docs/rules/no-unnecessary-whitespace.md) | Disallow unnecessary whitespace in tailwind classes. | ✔ | ✔ | ✔ | ✔ |
 
 #### Correctness rules
 

--- a/docs/rules/enforce-shorthand-classes.md
+++ b/docs/rules/enforce-shorthand-classes.md
@@ -1,0 +1,84 @@
+# better-tailwindcss/enforce-shorthand-classes
+
+Enforce shorthand class names instead of longhand class names.
+
+This rule identifies when multiple longhand Tailwind CSS classes can be replaced with a single shorthand class, improving code readability and reducing bundle size.
+
+<br/>
+
+## Options
+
+<br/>
+
+<details>
+  <summary>Common options</summary>
+
+  <br/>
+
+  These options are common to all rules and can also be set globally via the [`settings` object](../settings/settings.md).
+
+  <br/>
+
+### `attributes`
+
+  The name of the attribute that contains the tailwind classes.  
+
+  **Type**: Array of [Matchers](../configuration/advanced.md)  
+  **Default**: [Name](../configuration/advanced.md#name-based-matching) for `"class"` and [strings Matcher](../configuration/advanced.md#types-of-matchers) for `"class", "className"`
+
+  <br/>
+
+### `callees`
+
+  List of function names which arguments should also get linted.
+  
+  **Type**: Array of [Matchers](../configuration/advanced.md)  
+  **Default**: [Matchers](../configuration/advanced.md#types-of-matchers) for `"cc", "clb", "clsx", "cn", "cnb", "ctl", "cva", "cx", "dcnb", "objstr", "tv", "twJoin", "twMerge"`
+
+  <br/>
+
+### `variables`
+
+  List of variable names whose initializer should also get linted.  
+  
+  **Type**: Array of [Matchers](../configuration/advanced.md)  
+  **Default**:  [strings Matcher](../configuration/advanced.md#types-of-matchers) for `"className", "classNames", "classes", "style", "styles"`
+
+  <br/>
+
+### `tags`
+
+  List of template literal tag names whose content should get linted.  
+  
+  **Type**: Array of [Matchers](../configuration/advanced.md)  
+  **Default**: None
+
+  Note: When using the `tags` option, it is recommended to use the [strings Matcher](../configuration/advanced.md#types-of-matchers) for your tag names. This will ensure that nested expressions get linted correctly.
+
+</details>
+
+<br/>
+
+## Examples
+
+### Size Classes
+
+```tsx
+// ❌ BAD: using separate padding classes
+<div class="pt-4 pr-4 pb-4 pl-4" />;
+```
+
+```tsx
+// ✅ GOOD: using shorthand padding class
+<div class="p-4" />;
+```
+
+```tsx
+// ❌ BAD: using separate width and height classes
+<div class="w-4 h-4" />;
+```
+
+```tsx
+// ✅ GOOD: using shorthand size class
+<div class="size-4" />;
+```

--- a/src/configs/config.ts
+++ b/src/configs/config.ts
@@ -3,6 +3,7 @@ import { sortClasses } from "better-tailwindcss:rules/deprecated/sort-classes.js
 import { enforceConsistentClassOrder } from "better-tailwindcss:rules/enforce-consistent-class-order.js";
 import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
 import { enforceConsistentVariableSyntax } from "better-tailwindcss:rules/enforce-consistent-variable-syntax.js";
+import { enforceShorthandClasses } from "better-tailwindcss:rules/enforce-shorthand-classes.js";
 import { noConflictingClasses } from "better-tailwindcss:rules/no-conflicting-classes.js";
 import { noDuplicateClasses } from "better-tailwindcss:rules/no-duplicate-classes.js";
 import { noRestrictedClasses } from "better-tailwindcss:rules/no-restricted-classes.js";
@@ -23,6 +24,7 @@ const plugin = {
     [enforceConsistentClassOrder.name]: enforceConsistentClassOrder.rule,
     [enforceConsistentLineWrapping.name]: enforceConsistentLineWrapping.rule,
     [enforceConsistentVariableSyntax.name]: enforceConsistentVariableSyntax.rule,
+    [enforceShorthandClasses.name]: enforceShorthandClasses.rule,
     [noConflictingClasses.name]: noConflictingClasses.rule,
     [noDuplicateClasses.name]: noDuplicateClasses.rule,
     [noRestrictedClasses.name]: noRestrictedClasses.rule,

--- a/src/rules/enforce-shorthand-classes.test.ts
+++ b/src/rules/enforce-shorthand-classes.test.ts
@@ -1,0 +1,199 @@
+import { describe, it } from "vitest";
+
+import { enforceShorthandClasses } from "better-tailwindcss:rules/enforce-shorthand-classes.js";
+import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
+
+
+describe(enforceShorthandClasses.name, () => {
+
+  it("should not report on shorthand classes", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="size-4" />`,
+            html: `<img class="size-4" />`,
+            jsx: `() => <img class="size-4" />`,
+            svelte: `<img class="size-4" />`,
+            vue: `<template><img class="size-4" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should not report on classes that have no shorthand", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="flex" />`,
+            html: `<img class="flex" />`,
+            jsx: `() => <img class="flex" />`,
+            svelte: `<img class="flex" />`,
+            vue: `<template><img class="flex" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should collapse multiple classes into their shorthand", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="w-4 h-4" />`,
+            angularOutput: `<img class="size-4" />`,
+            html: `<img class="w-4 h-4" />`,
+            htmlOutput: `<img class="size-4" />`,
+            jsx: `() => <img class="w-4 h-4" />`,
+            jsxOutput: `() => <img class="size-4" />`,
+            svelte: `<img class="w-4 h-4" />`,
+            svelteOutput: `<img class="size-4" />`,
+            vue: `<template><img class="w-4 h-4" /></template>`,
+            vueOutput: `<template><img class="size-4" /></template>`,
+
+            errors: 1
+          }
+        ]
+      }
+    );
+  });
+
+  it("should not collapse classes if they have a different sign", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="w-4 -h-4" />`,
+            html: `<img class="w-4 -h-4" />`,
+            jsx: `() => <img class="w-4 -h-4" />`,
+            svelte: `<img class="w-4 -h-4" />`,
+            vue: `<template><img class="w-4 -h-4" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should collapse many classes into their shorthand", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="pt-4 pr-4 pb-4 pl-4" />`,
+            angularOutput: `<img class="p-4" />`,
+            html: `<img class="pt-4 pr-4 pb-4 pl-4" />`,
+            htmlOutput: `<img class="p-4" />`,
+            jsx: `() => <img class="pt-4 pr-4 pb-4 pl-4" />`,
+            jsxOutput: `() => <img class="p-4" />`,
+            svelte: `<img class="pt-4 pr-4 pb-4 pl-4" />`,
+            svelteOutput: `<img class="p-4" />`,
+            vue: `<template><img class="pt-4 pr-4 pb-4 pl-4" /></template>`,
+            vueOutput: `<template><img class="p-4" /></template>`,
+
+            errors: 1
+          }
+        ]
+      }
+    );
+  });
+
+  it("should not collapse differing classes into an otherwise valid shorthand", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="pt-4 pr-2 pb-4 pl-4" />`,
+            angularOutput: `<img class="py-4 pr-2 pl-4" />`,
+            html: `<img class="pt-4 pr-2 pb-4 pl-4" />`,
+            htmlOutput: `<img class="py-4 pr-2 pl-4" />`,
+            jsx: `() => <img class="pt-4 pr-2 pb-4 pl-4" />`,
+            jsxOutput: `() => <img class="py-4 pr-2 pl-4" />`,
+            svelte: `<img class="pt-4 pr-2 pb-4 pl-4" />`,
+            svelteOutput: `<img class="py-4 pr-2 pl-4" />`,
+            vue: `<template><img class="pt-4 pr-2 pb-4 pl-4" /></template>`,
+            vueOutput: `<template><img class="py-4 pr-2 pl-4" /></template>`,
+
+            errors: 1
+          }
+        ]
+      }
+    );
+  });
+
+  it("should work with variants", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="hover:w-4 hover:h-4" />`,
+            angularOutput: `<img class="hover:size-4" />`,
+            html: `<img class="hover:w-4 hover:h-4" />`,
+            htmlOutput: `<img class="hover:size-4" />`,
+            jsx: `() => <img class="hover:w-4 hover:h-4" />`,
+            jsxOutput: `() => <img class="hover:size-4" />`,
+            svelte: `<img class="hover:w-4 hover:h-4" />`,
+            svelteOutput: `<img class="hover:size-4" />`,
+            vue: `<template><img class="hover:w-4 hover:h-4" /></template>`,
+            vueOutput: `<template><img class="hover:size-4" /></template>`,
+
+            errors: 1
+          }
+        ]
+      }
+    );
+  });
+
+  it("should not report when one instance has a variant", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="w-4 hover:h-4" />`,
+            html: `<img class="w-4 hover:h-4" />`,
+            jsx: `() => <img class="w-4 hover:h-4" />`,
+            svelte: `<img class="w-4 hover:h-4" />`,
+            vue: `<template><img class="w-4 hover:h-4" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+  it("should not report when one instance has a different variant", () => {
+    lint(
+      enforceShorthandClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<img class="focus:w-4 hover:h-4" />`,
+            html: `<img class="focus:w-4 hover:h-4" />`,
+            jsx: `() => <img class="focus:w-4 hover:h-4" />`,
+            svelte: `<img class="focus:w-4 hover:h-4" />`,
+            vue: `<template><img class="focus:w-4 hover:h-4" /></template>`
+          }
+        ]
+      }
+    );
+  });
+
+});

--- a/src/rules/enforce-shorthand-classes.ts
+++ b/src/rules/enforce-shorthand-classes.ts
@@ -1,0 +1,312 @@
+import {
+  DEFAULT_ATTRIBUTE_NAMES,
+  DEFAULT_CALLEE_NAMES,
+  DEFAULT_TAG_NAMES,
+  DEFAULT_VARIABLE_NAMES
+} from "better-tailwindcss:options/default-options.js";
+import {
+  ATTRIBUTE_SCHEMA,
+  CALLEE_SCHEMA,
+  ENTRYPOINT_SCHEMA,
+  TAG_SCHEMA,
+  TAILWIND_CONFIG_SCHEMA,
+  VARIABLE_SCHEMA
+} from "better-tailwindcss:options/descriptions.js";
+import { getCommonOptions } from "better-tailwindcss:utils/options.js";
+import { escapeNestedQuotes } from "better-tailwindcss:utils/quotes.js";
+import { createRuleListener } from "better-tailwindcss:utils/rule.js";
+import {
+  augmentMessageWithWarnings,
+  display,
+  replacePlaceholders,
+  splitClasses
+} from "better-tailwindcss:utils/utils.js";
+
+import type { Rule } from "eslint";
+
+import type { Literal } from "better-tailwindcss:types/ast.js";
+import type {
+  AttributeOption,
+  CalleeOption,
+  ESLintRule,
+  TagOption,
+  VariableOption
+} from "better-tailwindcss:types/rule.js";
+
+
+export type Options = [
+  Partial<
+    AttributeOption &
+    CalleeOption &
+    TagOption &
+    VariableOption &
+    {
+      entryPoint?: string;
+      shorthands?: Shorthands;
+      tailwindConfig?: string;
+    }
+  >
+];
+
+export type Shorthands = [classes: string[], shorthand: string[]][][];
+
+export const shorthandGroups = [
+  [
+    [["(.*)w-(.*)", "(.*)h-(.*)"], ["$1size-$2"]]
+  ],
+  [
+    [["(.*)ml-(.*)", "(.*)mr-(.*)", "(.*)mt-(.*)", "(.*)mb-(.*)"], ["$1m-$2"]],
+    [["(.*)mx-(.*)", "(.*)my-(.*)"], ["$1m-$2"]],
+    [["(.*)ms-(.*)", "(.*)me-(.*)"], ["$1mx-$2"]],
+    [["(.*)ml-(.*)", "(.*)mr-(.*)"], ["$1mx-$2"]],
+    [["(.*)mt-(.*)", "(.*)mb-(.*)"], ["$1my-$2"]]
+  ],
+  [
+    [["(.*)pl-(.*)", "(.*)pr-(.*)", "(.*)pt-(.*)", "(.*)pb-(.*)"], ["$1p-$2"]],
+    [["(.*)px-(.*)", "(.*)py-(.*)"], ["$1p-$2"]],
+    [["(.*)ps-(.*)", "(.*)pe-(.*)"], ["$1px-$2"]],
+    [["(.*)pl-(.*)", "(.*)pr-(.*)"], ["$1px-$2"]],
+    [["(.*)pt-(.*)", "(.*)pb-(.*)"], ["$1py-$2"]]
+  ],
+  [
+    [["(.*)border-t-(.*)", "(.*)border-b-(.*)", "(.*)border-l-(.*)", "(.*)border-r-(.*)"], ["$1border-$2"]],
+    [["(.*)border-x-(.*)", "(.*)border-y-(.*)"], ["$1border-$2"]],
+    [["(.*)border-s-(.*)", "(.*)border-e-(.*)"], ["$1border-x-$2"]],
+    [["(.*)border-l-(.*)", "(.*)border-r-(.*)"], ["$1border-x-$2"]],
+    [["(.*)border-t-(.*)", "(.*)border-b-(.*)"], ["$1border-y-$2"]]
+  ],
+  [
+    [["(.*)border-spacing-x-(.*)", "(.*)border-spacing-y-(.*)"], ["$1border-spacing-$2"]]
+  ],
+  [
+    [["(.*)rounded-tl-(.*)", "(.*)rounded-tr-(.*)", "(.*)rounded-bl-(.*)", "(.*)rounded-br-(.*)"], ["$1rounded-$2"]],
+    [["(.*)rounded-tl-(.*)", "(.*)rounded-tr-(.*)"], ["$1rounded-t-$2"]],
+    [["(.*)rounded-bl-(.*)", "(.*)rounded-br-(.*)"], ["$1rounded-b-$2"]],
+    [["(.*)rounded-tl-(.*)", "(.*)rounded-bl-(.*)"], ["$1rounded-l-$2"]],
+    [["(.*)rounded-tr-(.*)", "(.*)rounded-br-(.*)"], ["$1rounded-r-$2"]]
+  ],
+  [
+    [["(.*)scroll-mt-(.*)", "(.*)scroll-mb-(.*)", "(.*)scroll-ml-(.*)", "(.*)scroll-mr-(.*)"], ["$1scroll-m-$2"]],
+    [["(.*)scroll-mx-(.*)", "(.*)scroll-my-(.*)"], ["$1scroll-m-$2"]],
+    [["(.*)scroll-ms-(.*)", "(.*)scroll-me-(.*)"], ["$1scroll-mx-$2"]],
+    [["(.*)scroll-ml-(.*)", "(.*)scroll-mr-(.*)"], ["$1scroll-mx-$2"]],
+    [["(.*)scroll-mt-(.*)", "(.*)scroll-mb-(.*)"], ["$1scroll-my-$2"]]
+  ],
+  [
+    [["(.*)scroll-pt-(.*)", "(.*)scroll-pb-(.*)", "(.*)scroll-pl-(.*)", "(.*)scroll-pr-(.*)"], ["$1scroll-p-$2"]],
+    [["(.*)scroll-px-(.*)", "(.*)scroll-py-(.*)"], ["$1scroll-p-$2"]],
+    [["(.*)scroll-pl-(.*)", "(.*)scroll-pr-(.*)"], ["$1scroll-px-$2"]],
+    [["(.*)scroll-ps-(.*)", "(.*)scroll-pe-(.*)"], ["$1scroll-px-$2"]],
+    [["(.*)scroll-pt-(.*)", "(.*)scroll-pb-(.*)"], ["$1scroll-py-$2"]]
+  ],
+  [
+    [["(.*)top-(.*)", "(.*)right-(.*)", "(.*)bottom-(.*)", "(.*)left-(.*)"], ["$1inset-$2"]],
+    [["(.*)inset-x-(.*)", "(.*)inset-y-(.*)"], ["$1inset-$2"]]
+  ],
+  [
+    [["(.*)divide-x-(.*)", "(.*)divide-y-(.*)"], ["$1divide-$2"]]
+  ],
+  [
+    [["(.*)space-x-(.*)", "(.*)space-y-(.*)"], ["$1space-$2"]]
+  ],
+  [
+    [["(.*)gap-x-(.*)", "(.*)gap-y-(.*)"], ["$1gap-$2"]]
+  ],
+  [
+    [["(.*)translate-x-(.*)", "(.*)translate-y-(.*)", "(.*)translate-z-(.*)"], ["$1translate-$2", "$1translate-3d"]],
+    [["(.*)translate-x-(.*)", "(.*)translate-y-(.*)"], ["$1translate-$2"]]
+  ],
+  [
+    [["(.*)rotate-x-(.*)", "(.*)rotate-y-(.*)"], ["$1rotate-$2"]]
+  ],
+  [
+    [["(.*)skew-x-(.*)", "(.*)skew-y-(.*)"], ["$1skew-$2"]]
+  ],
+  [
+    [["(.*)scale-x-(.*)", "(.*)scale-y-(.*)", "(.*)scale-z-(.*)"], ["$1scale-$2", "$1scale-3d"]],
+    [["(.*)scale-x-(.*)", "(.*)scale-y-(.*)"], ["$1scale-$2"]]
+  ],
+  [
+    [["(.*)content-(.*)", "(.*)justify-content-(.*)"], ["$1place-content-$2"]],
+    [["(.*)items-(.*)", "(.*)justify-items-(.*)"], ["$1place-items-$2"]],
+    [["(.*)self-(.*)", "(.*)justify-self-(.*)"], ["$1place-self-$2"]]
+  ],
+  [
+    [["(.*)overflow-hidden", "(.*)text-ellipsis", "(.*)whitespace-nowrap"], ["$1truncate"]]
+  ]
+] satisfies Shorthands;
+
+const defaultOptions = {
+  attributes: DEFAULT_ATTRIBUTE_NAMES,
+  callees: DEFAULT_CALLEE_NAMES,
+  tags: DEFAULT_TAG_NAMES,
+  variables: DEFAULT_VARIABLE_NAMES
+} as const satisfies Options[0];
+
+const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/prefer-shorthand.md";
+
+export const enforceShorthandClasses: ESLintRule<Options> = {
+  name: "enforce-shorthand-classes" as const,
+  rule: {
+    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    meta: {
+      docs: {
+        description: "Enforce shorthand class names instead of longhand class names.",
+        recommended: false,
+        url: DOCUMENTATION_URL
+      },
+      fixable: "code",
+      schema: [
+        {
+          additionalProperties: false,
+          properties: {
+            ...CALLEE_SCHEMA,
+            ...ATTRIBUTE_SCHEMA,
+            ...VARIABLE_SCHEMA,
+            ...TAG_SCHEMA,
+            ...ENTRYPOINT_SCHEMA,
+            ...TAILWIND_CONFIG_SCHEMA
+          },
+          type: "object"
+        }
+      ],
+      type: "problem"
+    }
+  }
+};
+
+function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
+
+  for(const literal of literals){
+
+    const classes = splitClasses(literal.content);
+
+    const shorthandClasses = getShorthandClasses(classes);
+
+    for(const [longhands, shorthands] of shorthandClasses){
+      const finalClasses: string[] = [];
+
+      for(const className of classes){
+
+        if(!longhands.includes(className)){
+          finalClasses.push(className);
+          continue;
+        }
+
+        if(shorthands.some(shorthand => finalClasses.includes(shorthand))){
+          continue;
+        }
+
+        finalClasses.push(...shorthands);
+      }
+
+      const escapedClasses = escapeNestedQuotes(
+        finalClasses.join(" "),
+        literal.openingQuote ?? literal.closingQuote ?? "`"
+      );
+
+      const fixedClasses =
+      [
+        literal.openingQuote ?? "",
+        literal.type === "TemplateLiteral" && literal.closingBraces ? literal.closingBraces : "",
+        escapedClasses,
+        literal.type === "TemplateLiteral" && literal.openingBraces ? literal.openingBraces : "",
+        literal.closingQuote ?? ""
+      ].join("");
+
+      if(literal.raw === fixedClasses){
+        continue;
+      }
+
+      ctx.report({
+        data: {
+          longhand: display(longhands.join(", ")),
+          shorthand: display(shorthands.join(", "))
+        },
+        fix(fixer) {
+          return fixer.replaceTextRange(literal.range, fixedClasses);
+        },
+        loc: literal.loc,
+        message: augmentMessageWithWarnings(
+          "Non shorthand class detected. Expected {{ longhand }} to be {{ shorthand }}",
+          DOCUMENTATION_URL
+        )
+      });
+    }
+  }
+}
+
+type Shorthand = [classNames: string[], shorthands: string[]];
+
+function getShorthandClasses(classes: string[]): Shorthand[] {
+
+  let finalShorthandClasses: Shorthand[] = [];
+
+  const maxIterations = shorthandGroups.reduce((acc, shortHandGroups) => {
+    if(acc >= shortHandGroups.length){
+      return acc;
+    }
+    return shortHandGroups.length;
+  }, 0);
+
+  for(let i = 0; i < maxIterations; i++){
+    const shorthandClasses: Shorthand[] = [];
+
+    shorthandGroupLoop: for(const shorthandGroup of shorthandGroups){
+
+      const sortedShorthandGroup = shorthandGroup.sort((a, b) => b[0].length - a[0].length);
+
+      shorthandLoop: for(const [classPatterns, substitutes] of sortedShorthandGroup){
+
+        const longhands: string[] = [];
+        const groups: string[] = [];
+
+        for(const classPattern of classPatterns){
+          classNameLoop: for(const className of classes){
+            const match = className.match(new RegExp(classPattern));
+
+            if(!match){
+              continue classNameLoop;
+            }
+
+            for(let m = 0; m < match.length; m++){
+              if(groups[m] === undefined){
+                groups[m] = match[m];
+                continue;
+              }
+
+              if(m === 0){
+                continue;
+              }
+
+              if(groups[m] !== match[m]){
+                continue shorthandLoop;
+              }
+            }
+
+            longhands.push(className);
+          }
+        }
+
+        if(longhands.length === classPatterns.length){
+          shorthandClasses.push([longhands, substitutes.map(substitute => replacePlaceholders(substitute, groups))]);
+          continue shorthandGroupLoop;
+        }
+      }
+
+    }
+
+    if(shorthandClasses.length === finalShorthandClasses.length && shorthandClasses.every((shorthand, index) => shorthand[0].length === finalShorthandClasses[index][0].length &&
+      shorthand[1].length === finalShorthandClasses[index][1].length)){
+      break;
+    }
+
+    finalShorthandClasses = structuredClone(shorthandClasses);
+  }
+
+  return finalShorthandClasses;
+}
+
+export function getOptions(ctx: Rule.RuleContext) {
+  return getCommonOptions(ctx);
+}

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -43,7 +43,7 @@ export function display(classes: string): string {
     .replaceAll("\t", "→");
 }
 
-export function replacePlaceholders(template: string, match: RegExpMatchArray): string {
+export function replacePlaceholders(template: string, match: RegExpMatchArray | string[]): string {
   return template.replace(/\$(\d+)/g, (_, groupIndex) => {
     const index = Number(groupIndex);
     return match[index] ?? "";


### PR DESCRIPTION
closes: #140 

```tsx
// ❌ BAD: using separate padding classes
<div class="pt-4 pr-4 pb-4 pl-4" />;
```

```tsx
// ✅ GOOD: using shorthand padding classa
<div class="p-4" />;
```