### PR TITLE
fix: component classes improvements

### DIFF
--- a/src/async-utils/resolvers.ts
+++ b/src/async-utils/resolvers.ts
@@ -35,3 +35,20 @@ export const jsonResolver = enhancedResolve.ResolverFactory.createResolver({
   fileSystem,
   useSyncFileSystemCalls: true
 });
+
+
+export function resolveJs(base: string, id: string): string {
+  try {
+    return esmResolver.resolveSync({}, base, id) || id;
+  } catch {
+    return cjsResolver.resolveSync({}, base, id) || id;
+  }
+}
+
+export function resolveCss(base: string, id: string): string {
+  try {
+    return cssResolver.resolveSync({}, base, id) || id;
+  } catch {
+    return id;
+  }
+}

--- a/src/async-utils/resolvers.ts
+++ b/src/async-utils/resolvers.ts
@@ -37,18 +37,26 @@ export const jsonResolver = enhancedResolve.ResolverFactory.createResolver({
 });
 
 
-export function resolveJs(base: string, id: string): string {
+export function resolveJs(cwd: string, path: string): string {
   try {
-    return esmResolver.resolveSync({}, base, id) || id;
+    return esmResolver.resolveSync({}, cwd, path) || path;
   } catch {
-    return cjsResolver.resolveSync({}, base, id) || id;
+    return cjsResolver.resolveSync({}, cwd, path) || path;
   }
 }
 
-export function resolveCss(base: string, id: string): string {
+export function resolveCss(cwd: string, path: string): string {
   try {
-    return cssResolver.resolveSync({}, base, id) || id;
+    return cssResolver.resolveSync({}, cwd, path) || path;
   } catch {
-    return id;
+    return path;
+  }
+}
+
+export function resolveJson(cwd: string, path: string): string {
+  try {
+    return jsonResolver.resolveSync({}, cwd, path) || path;
+  } catch {
+    return path;
   }
 }

--- a/src/async-utils/version.ts
+++ b/src/async-utils/version.ts
@@ -1,7 +1,8 @@
 import { readFileSync } from "node:fs";
+import { cwd } from "node:process";
 
 import { withCache } from "./cache.js";
-import { jsonResolver } from "./resolvers.js";
+import { resolveJson } from "./resolvers.js";
 
 
 export const enum TailwindcssVersion {
@@ -24,7 +25,7 @@ export function isTailwindcssVersion4(version: number): version is TailwindcssVe
 }
 
 export function getTailwindcssVersion() {
-  const packageJsonPath = jsonResolver.resolveSync({}, process.cwd(), "tailwindcss/package.json");
+  const packageJsonPath = resolveJson(cwd(), "tailwindcss/package.json");
 
   if(!packageJsonPath){
     throw new Error("Could not find a Tailwind CSS package.json");

--- a/src/rules/no-unregistered-classes.test.ts
+++ b/src/rules/no-unregistered-classes.test.ts
@@ -289,7 +289,7 @@ describe(noUnregisteredClasses.name, () => {
     );
   });
 
-  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should ignore custom classes defined in the component layer in tailwind >= 4", () => {
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should ignore custom component classes defined in the component layer in tailwind >= 4", () => {
     lint(
       noUnregisteredClasses,
       TEST_SYNTAXES,
@@ -350,7 +350,7 @@ describe(noUnregisteredClasses.name, () => {
     );
   });
 
-  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should ignore custom classes defined in imported files in tailwind >= 4", () => {
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should ignore custom component classes defined in imported files in tailwind >= 4", () => {
     lint(
       noUnregisteredClasses,
       TEST_SYNTAXES,
@@ -406,6 +406,37 @@ describe(noUnregisteredClasses.name, () => {
               "tailwind.css": css`
                 @import "tailwindcss";
                 @import "./nested/import.css";
+              `
+            },
+            options: [{
+              detectComponentClasses: true,
+              entryPoint: "./tailwind.css"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should not crash when trying to read custom component classes in a file that doesn't exists in tailwind >= 4", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="custom-component unregistered" />`,
+            html: `<img class="custom-component unregistered" />`,
+            jsx: `() => <img class="custom-component unregistered" />`,
+            svelte: `<img class="custom-component unregistered" />`,
+            vue: `<template><img class="custom-component unregistered" /></template>`,
+
+            errors: 2,
+
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss";
+                @import "./does-not-exist.css";
               `
             },
             options: [{

--- a/src/tailwindcss/custom-component-classes.async.v4.ts
+++ b/src/tailwindcss/custom-component-classes.async.v4.ts
@@ -28,14 +28,14 @@ export function getCustomComponentClasses({ configPath, cwd }: GetCustomComponen
   return utilities;
 }
 
-function parseCssFile(cwd: string, filePath: string): { [filePath: string]: CssNode; } {
+export function parseCssFile(cwd: string, filePath: string): { [filePath: string]: CssNode; } {
   const resolvedPath = resolveCss(cwd, filePath);
 
   return withCache(resolvedPath, () => {
     try {
       const content = readFileSync(resolvedPath, "utf-8");
 
-      const files: { [resolvedPath: string]: CssNode; } = {
+      const files: { [filePath: string]: CssNode; } = {
         [resolvedPath]: parse(content)
       };
 
@@ -48,12 +48,13 @@ function parseCssFile(cwd: string, filePath: string): { [filePath: string]: CssN
           continue;
         }
 
-        const importPath = generate(importNode.prelude).trim()
-          .replace(/["']/g, "");
+        const importStatement = generate(importNode.prelude).match(/["'](?<importPath>[^"']+)["']/);
 
-        if(!importPath.endsWith(".css")){
+        if(!importStatement){
           continue;
         }
+
+        const { importPath } = importStatement.groups || {};
 
         const cwd = dirname(resolvedPath);
         const importFiles = parseCssFile(cwd, importPath);

--- a/src/tailwindcss/custom-component-classes.ts
+++ b/src/tailwindcss/custom-component-classes.ts
@@ -6,7 +6,6 @@ import { resolve } from "node:path";
 import { createSyncFn } from "synckit";
 
 import { getTailwindConfigPath } from "better-tailwindcss:tailwindcss/config.js";
-import { invalidateByModifiedDate, withCache } from "better-tailwindcss:utils/cache.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
 import type { Async } from "better-tailwindcss:types/async.js";
@@ -22,9 +21,7 @@ export type GetCustomComponentClassesResponse = string[];
 export function getCustomComponentClasses({ configPath, cwd }: { configPath: string | undefined; cwd: string; }) {
   const { path } = getTailwindConfigPath({ configPath, cwd });
 
-  return withCache("custom-components", () => {
-    return getCustomComponentClassesSync({ configPath: path, cwd });
-  }, date => invalidateByModifiedDate(date, path));
+  return getCustomComponentClassesSync({ configPath: path, cwd });
 }
 
 const getCustomComponentClassesSync = createSyncFn<

--- a/src/tailwindcss/custom-component-classes.ts
+++ b/src/tailwindcss/custom-component-classes.ts
@@ -14,6 +14,7 @@ import type { Async } from "better-tailwindcss:types/async.js";
 
 export interface GetCustomComponentClassesRequest {
   configPath: string;
+  cwd: string;
 }
 
 export type GetCustomComponentClassesResponse = string[];
@@ -22,7 +23,7 @@ export function getCustomComponentClasses({ configPath, cwd }: { configPath: str
   const { path } = getTailwindConfigPath({ configPath, cwd });
 
   return withCache("custom-components", () => {
-    return getCustomComponentClassesSync({ configPath: path });
+    return getCustomComponentClassesSync({ configPath: path, cwd });
   }, date => invalidateByModifiedDate(date, path));
 }
 


### PR DESCRIPTION
- Fixes crash when importing css files via tsconfig path alias and [`detectComponentClasses`](https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/rules/no-unregistered-classes.md#detectcomponentclasses) enabled
- Fixes component classes not getting updated when inside an imported file