### PR TITLE
fix: disallow extra properties in rule options

### DIFF
--- a/src/options/descriptions.ts
+++ b/src/options/descriptions.ts
@@ -4,6 +4,7 @@ import type { Rule } from "eslint";
 
 
 const STRING_MATCHER_SCHEMA = {
+  additionalProperties: false,
   properties: {
     match: {
       description: "Matcher type that will be applied.",
@@ -15,6 +16,7 @@ const STRING_MATCHER_SCHEMA = {
 } satisfies Rule.RuleMetaData["schema"];
 
 const OBJECT_KEY_MATCHER_SCHEMA = {
+  additionalProperties: false,
   properties: {
     match: {
       description: "Matcher type that will be applied.",
@@ -30,6 +32,7 @@ const OBJECT_KEY_MATCHER_SCHEMA = {
 } satisfies Rule.RuleMetaData["schema"];
 
 const OBJECT_VALUE_MATCHER_SCHEMA = {
+  additionalProperties: false,
   properties: {
     match: {
       description: "Matcher type that will be applied.",


### PR DESCRIPTION
The rules currently allow extra properties to be passed in options object, which should not be allowed. This makes it easier for typos in rule options to go unnoticed.

This PR simply disallows extra properties in rules' schemas which currently allow them.