### PR TITLE
refactor: add missing deprecations

### DIFF
--- a/src/rules/no-deprecated-classes.test.ts
+++ b/src/rules/no-deprecated-classes.test.ts
@@ -6,6 +6,40 @@ import { css } from "better-tailwindcss:tests/utils/template.js";
 import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
 
 
+const testCases = [
+  ["shadow", "shadow-sm"],
+  ["inset-shadow", "inset-shadow-sm"],
+  ["drop-shadow", "drop-shadow-sm"],
+  ["blur", "blur-sm"],
+  ["backdrop-blur", "backdrop-blur-sm"],
+  ["rounded", "rounded-sm"],
+
+  ["bg-opacity-70", undefined],
+  ["text-opacity-70", undefined],
+  ["border-opacity-70", undefined],
+  ["divide-opacity-70", undefined],
+  ["ring-opacity-70", undefined],
+  ["placeholder-opacity-70", undefined],
+
+  ["flex-shrink-1", "shrink-1"],
+  ["flex-grow-1", "grow-1"],
+
+  ["overflow-ellipsis", "text-ellipsis"],
+
+  ["decoration-slice", "box-decoration-slice"],
+  ["decoration-clone", "box-decoration-clone"],
+
+  // 4.1 deprecations
+  ["bg-left-top", "bg-top-left"],
+  ["bg-left-bottom", "bg-bottom-left"],
+  ["bg-right-top", "bg-top-right"],
+  ["bg-right-bottom", "bg-bottom-right"],
+  ["object-left-top", "object-top-left"],
+  ["object-left-bottom", "object-bottom-left"],
+  ["object-right-top", "object-top-right"],
+  ["object-right-bottom", "object-bottom-right"]
+] satisfies [string, string | undefined][];
+
 describe.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)(noDeprecatedClasses.name, () => {
 
   it("should not report valid classes", () => {
@@ -227,6 +261,55 @@ describe.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)(noDepreca
         ]
       }
     );
+
+  });
+
+  it.each(testCases)(`should report "%s"`, (input, output) => {
+
+    const hasFix = output !== undefined;
+
+    if(hasFix){
+      lint(
+        noDeprecatedClasses,
+        TEST_SYNTAXES,
+        {
+          invalid: [
+            {
+              angular: `<img class="${input}" />`,
+              angularOutput: `<img class="${output}" />`,
+              html: `<img class="${input}" />`,
+              htmlOutput: `<img class="${output}" />`,
+              jsx: `() => <img class="${input}" />`,
+              jsxOutput: `() => <img class="${output}" />`,
+              svelte: `<img class="${input}" />`,
+              svelteOutput: `<img class="${output}" />`,
+              vue: `<template><img class="${input}" /></template>`,
+              vueOutput: `<template><img class="${output}" /></template>`,
+
+              errors: 1
+            }
+          ]
+        }
+      );
+    } else {
+      lint(
+        noDeprecatedClasses,
+        TEST_SYNTAXES,
+        {
+          invalid: [
+            {
+              angular: `<img class="${input}" />`,
+              html: `<img class="${input}" />`,
+              jsx: `() => <img class="${input}" />`,
+              svelte: `<img class="${input}" />`,
+              vue: `<template><img class="${input}" /></template>`,
+
+              errors: 1
+            }
+          ]
+        }
+      );
+    }
 
   });
 

--- a/src/rules/no-deprecated-classes.ts
+++ b/src/rules/no-deprecated-classes.ts
@@ -18,6 +18,7 @@ import { lintClasses } from "better-tailwindcss:utils/lint.js";
 import { getCommonOptions } from "better-tailwindcss:utils/options.js";
 import { createRuleListener } from "better-tailwindcss:utils/rule.js";
 import { augmentMessageWithWarnings, replacePlaceholders, splitClasses } from "better-tailwindcss:utils/utils.js";
+import { getTailwindcssVersion } from "better-tailwindcss:utils/version.js";
 
 import type { Rule } from "eslint";
 
@@ -85,31 +86,48 @@ export const noDeprecatedClasses: ESLintRule<Options> = {
 };
 
 const deprecations = [
-  [/^shadow$/, "shadow-sm"],
-  [/^drop-shadow$/, "drop-shadow-sm"],
-  [/^blur$/, "blur-sm"],
-  [/^backdrop-blur$/, "backdrop-blur-sm"],
-  [/^rounded$/, "rounded-sm"],
+  [
+    { major: 4, minor: 0 }, [
+      [/^shadow$/, "shadow-sm"],
+      [/^inset-shadow$/, "inset-shadow-sm"],
+      [/^drop-shadow$/, "drop-shadow-sm"],
+      [/^blur$/, "blur-sm"],
+      [/^backdrop-blur$/, "backdrop-blur-sm"],
+      [/^rounded$/, "rounded-sm"],
 
-  [/^bg-opacity-(.*)$/],
-  [/^text-opacity-(.*)$/],
-  [/^border-opacity-(.*)$/],
-  [/^divide-opacity-(.*)$/],
-  [/^ring-opacity-(.*)$/],
-  [/^placeholder-opacity-(.*)$/],
+      [/^bg-opacity-(.*)$/],
+      [/^text-opacity-(.*)$/],
+      [/^border-opacity-(.*)$/],
+      [/^divide-opacity-(.*)$/],
+      [/^ring-opacity-(.*)$/],
+      [/^placeholder-opacity-(.*)$/],
 
-  [/^flex-shrink-(.*)$/, "shrink-$1"],
-  [/^flex-grow-(.*)$/, "grow-$1"],
+      [/^flex-shrink-(.*)$/, "shrink-$1"],
+      [/^flex-grow-(.*)$/, "grow-$1"],
 
-  [/^overflow-ellipsis$/, "text-ellipsis"],
+      [/^overflow-ellipsis$/, "text-ellipsis"],
 
-  [/^decoration-slice$/, "box-decoration-slice"],
-  [/^decoration-clone$/, "box-decoration-clone"]
-] satisfies [before: RegExp, after?: string][];
+      [/^decoration-slice$/, "box-decoration-slice"],
+      [/^decoration-clone$/, "box-decoration-clone"]
+    ]
+  ], [
+    { major: 4, minor: 1 }, [
+      [/^bg-left-top$/, "bg-top-left"],
+      [/^bg-left-bottom$/, "bg-bottom-left"],
+      [/^bg-right-top$/, "bg-top-right"],
+      [/^bg-right-bottom$/, "bg-bottom-right"],
+      [/^object-left-top$/, "object-top-left"],
+      [/^object-left-bottom$/, "object-bottom-left"],
+      [/^object-right-top$/, "object-top-right"],
+      [/^object-right-bottom$/, "object-bottom-right"]
+    ]
+  ]
+] satisfies [{ major: number; minor: number; }, [before: RegExp, after?: string][]][];
 
 function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
   const { tailwindConfig } = getOptions(ctx);
+  const { major, minor } = getTailwindcssVersion();
 
   for(const literal of literals){
 
@@ -124,34 +142,40 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         return;
       }
 
-      for(const [pattern, replacement] of deprecations){
-        const match = dissectedClass.base.match(pattern);
-
-        if(!match){
+      for(const [version, deprecation] of deprecations){
+        if(major < version.major || major === version.major && minor < version.minor){
           continue;
         }
 
-        if(!replacement){
+        for(const [pattern, replacement] of deprecation){
+          const match = dissectedClass.base.match(pattern);
+
+          if(!match){
+            continue;
+          }
+
+          if(!replacement){
+            return {
+              message: augmentMessageWithWarnings(
+                `Class "${className}" is deprecated. Check the tailwindcss documentation for more information: https://tailwindcss.com/docs/upgrade-guide#removed-deprecated-utilities`,
+                DOCUMENTATION_URL,
+                warnings
+              )
+            };
+          }
+
+          const fix = buildClass({ ...dissectedClass, base: replacePlaceholders(replacement, match) });
+
           return {
+            fix,
             message: augmentMessageWithWarnings(
-              `Class "${className}" is deprecated. Check the tailwindcss documentation for more information: https://tailwindcss.com/docs/upgrade-guide#removed-deprecated-utilities`,
+              `Deprecated class detected. Replace "${className}" with ${fix}.`,
               DOCUMENTATION_URL,
               warnings
             )
           };
+
         }
-
-        const fix = buildClass({ ...dissectedClass, base: replacePlaceholders(replacement, match) });
-
-        return {
-          fix,
-          message: augmentMessageWithWarnings(
-            `Deprecated class detected. Replace "${className}" with ${fix}.`,
-            DOCUMENTATION_URL,
-            warnings
-          )
-        };
-
       }
     });
 


### PR DESCRIPTION
Adds missing deprecations:

4.0

- `inset-shadow` -> `inset-shadow-sm`

4.1 

- `bg-left-top` -> `bg-top-left`
- `bg-left-bottom` -> `bg-bottom-left`
- `bg-right-top` -> `bg-top-right`
- `bg-right-bottom` -> `bg-bottom-right`
- `object-left-top` -> `object-top-left`
- `object-left-bottom` -> `object-bottom-left`
- `object-right-top` -> `object-top-right`
- `object-right-bottom` -> `object-bottom-right`