### PR TITLE
refactor: variable syntax tailwindcss3 shorthand

### DIFF
--- a/docs/rules/enforce-consistent-variable-syntax.md
+++ b/docs/rules/enforce-consistent-variable-syntax.md
@@ -94,6 +94,6 @@ Enforce consistent css variable syntax in tailwindcss class strings.
 ```
 
 ```tsx
-// ✅ GOOD: With option `syntax: "arbitrary"`
+// ✅ GOOD: With option `syntax: "variable"`
 <div class="bg-[var(--primary)]" />;
 ```

--- a/docs/rules/enforce-consistent-variable-syntax.md
+++ b/docs/rules/enforce-consistent-variable-syntax.md
@@ -10,8 +10,10 @@ Enforce consistent css variable syntax in tailwindcss class strings.
 
   The syntax to enforce for css variables in tailwindcss class strings.
 
-  **Type**: `"arbitrary"` | `"parentheses"`  
-  **Default**: `"parentheses"`
+  The `shorthand` syntax uses the `(--variable)` syntax in Tailwind CSS v4 and `[--variable]` syntax in Tailwind CSS v3.
+
+  **Type**: `"variable"` | `"shorthand"`  
+  **Default**: `"shorthand"`
 
 <br/>
 
@@ -67,18 +69,28 @@ Enforce consistent css variable syntax in tailwindcss class strings.
 ## Examples
 
 ```tsx
-// ❌ BAD: Incorrect css variable syntax with option `syntax: "parentheses"`
+// ❌ BAD: Incorrect css variable syntax with option `syntax: "shorthand"`
 <div class="bg-[var(--primary)]" />;
 ```
 
 ```tsx
-// ✅ GOOD: With option `syntax: "parentheses"`
+// ✅ GOOD: With option `syntax: "shorthand"` in Tailwind CSS v4
 <div class="bg-(--primary)" />;
 ```
 
 ```tsx
-// ❌ BAD: Incorrect css variable syntax with option `syntax: "arbitrary"`
+// ✅ GOOD: With option `syntax: "shorthand"` in Tailwind CSS v3
+<div class="bg-[--primary]" />;
+```
+
+```tsx
+// ❌ BAD: Incorrect css variable syntax with option `syntax: "variable"` in Tailwind CSS v4
 <div class="bg-(--primary)" />;
+```
+
+```tsx
+// ❌ BAD: Incorrect css variable syntax with option `syntax: "variable"` in Tailwind CSS v3
+<div class="bg-[--primary]" />;
 ```
 
 ```tsx

--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -133,7 +133,6 @@ describe(enforceConsistentVariableSyntax.name, () => {
     );
   });
 
-
   it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should convert variables to arbitrary shorthands in tailwind <= 3", () => {
     lint(
       enforceConsistentVariableSyntax,
@@ -582,7 +581,6 @@ describe(enforceConsistentVariableSyntax.name, () => {
     );
   });
 
-
   it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should preserve css functions in tailwind <= 3", () => {
     lint(
       enforceConsistentVariableSyntax,
@@ -965,6 +963,32 @@ describe(enforceConsistentVariableSyntax.name, () => {
             vueOutput: `<template><img class="${multilineShorthand}" /></template>`,
 
             errors: 2,
+            options: [{ syntax: "shorthand" }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should convert arbitrary shorthands to parenthesized shorthands in tailwind >= 4", () => {
+    lint(
+      enforceConsistentVariableSyntax,
+      TEST_SYNTAXES,
+      {
+        invalid: [
+          {
+            angular: `<img class="bg-[--brand]" />`,
+            angularOutput: `<img class="bg-(--brand)" />`,
+            html: `<img class="bg-[--brand]" />`,
+            htmlOutput: `<img class="bg-(--brand)" />`,
+            jsx: `() => <img class="bg-[--brand]" />`,
+            jsxOutput: `() => <img class="bg-(--brand)" />`,
+            svelte: `<img class="bg-[--brand]" />`,
+            svelteOutput: `<img class="bg-(--brand)" />`,
+            vue: `<template><img class="bg-[--brand]" /></template>`,
+            vueOutput: `<template><img class="bg-(--brand)" /></template>`,
+
+            errors: 1,
             options: [{ syntax: "shorthand" }]
           }
         ]

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -178,6 +178,31 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
             };
 
           }
+
+          if(isBeginningOfArbitraryShorthand(characters)){
+            if(major <= TailwindcssVersion.V3){
+              continue;
+            }
+
+            const start = i + 1 - (findOpeningBracketOffset(characters) ?? 0);
+
+            const [balancedArbitraryContent] = extractBalanced(className.slice(start), "[", "]");
+
+            if(!balancedArbitraryContent){
+              continue;
+            }
+
+            const end = start + balancedArbitraryContent.length + 2;
+
+            const fixedVariable = `${className.slice(0, start)}(${balancedArbitraryContent})${className.slice(end)}`;
+
+            return {
+              fix: fixedVariable,
+              message: `Incorrect variable syntax: "[${balancedArbitraryContent}]".`
+            };
+
+          }
+
         }
       }
     });

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -13,6 +13,7 @@ import {
 import { lintClasses } from "better-tailwindcss:utils/lint.js";
 import { getCommonOptions } from "better-tailwindcss:utils/options.js";
 import { createRuleListener } from "better-tailwindcss:utils/rule.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
 
 import type { Rule } from "eslint";
 
@@ -33,7 +34,7 @@ export type Options = [
     TagOption &
     VariableOption &
     {
-      syntax?: "arbitrary" | "parentheses";
+      syntax?: "arbitrary" | "parentheses" | "shorthand" | "variable";
     }
   >
 ];
@@ -42,7 +43,7 @@ export type Options = [
 const defaultOptions = {
   attributes: DEFAULT_ATTRIBUTE_NAMES,
   callees: DEFAULT_CALLEE_NAMES,
-  syntax: "parentheses",
+  syntax: "shorthand",
   tags: DEFAULT_TAG_NAMES,
   variables: DEFAULT_VARIABLE_NAMES
 } as const satisfies Options[0];
@@ -69,9 +70,9 @@ export const enforceConsistentVariableSyntax: ESLintRule<Options> = {
             ...VARIABLE_SCHEMA,
             ...TAG_SCHEMA,
             syntax: {
-              default: "parentheses",
-              description: "Preferred syntax for CSS variables. 'arbitrary' uses [var(--foo)], 'parentheses' uses (--foo).",
-              enum: ["arbitrary", "parentheses"],
+              default: "shorthand",
+              description: "Preferred syntax for CSS variables. 'variable' uses [var(--foo)], 'shorthand' uses (--foo) in Tailwind CSS v4 or [--foo] in Tailwind CSS v3.",
+              enum: ["arbitrary", "parentheses", "shorthand", "variable"],
               type: "string"
             }
           },
@@ -86,6 +87,7 @@ export const enforceConsistentVariableSyntax: ESLintRule<Options> = {
 function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
   const { syntax } = getOptions(ctx);
+  const { major } = getTailwindcssVersion();
 
   for(const literal of literals){
 
@@ -100,7 +102,7 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
         i++){
         characters.push(className[i]);
 
-        if(syntax === "arbitrary"){
+        if(syntax === "arbitrary" || syntax === "variable"){
 
           if(isInsideVar){
             continue;
@@ -127,9 +129,29 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
             };
 
           }
+
+          if(isBeginningOfArbitraryShorthand(characters)){
+            const start = i + 1 - (findOpeningBracketOffset(characters) ?? 0);
+
+            const [balancedArbitraryContent] = extractBalanced(className.slice(start), "[", "]");
+
+            if(!balancedArbitraryContent){
+              continue;
+            }
+
+            const end = start + balancedArbitraryContent.length + 2;
+
+            const fixedVariable = `${className.slice(0, start)}[var(${balancedArbitraryContent})]${className.slice(end)}`;
+
+            return {
+              fix: fixedVariable,
+              message: `Incorrect variable syntax: "[${balancedArbitraryContent}]".`
+            };
+
+          }
         }
 
-        if(syntax === "parentheses"){
+        if(syntax === "parentheses" || syntax === "shorthand"){
           if(isBeginningOfArbitraryVariable(characters)){
             if(isInsideBrackets){
               continue;
@@ -146,7 +168,9 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
             const end = start + balancedArbitraryContent.length + 2;
 
-            const fixedVariable = `${className.slice(0, start)}(${balancedVariableContent})${className.slice(end)}`;
+            const fixedVariable = major >= TailwindcssVersion.V4
+              ? `${className.slice(0, start)}(${balancedVariableContent})${className.slice(end)}`
+              : `${className.slice(0, start)}[${balancedVariableContent}]${className.slice(end)}`;
 
             return {
               fix: fixedVariable,
@@ -155,18 +179,28 @@ function lintLiterals(ctx: Rule.RuleContext, literals: Literal[]) {
 
           }
         }
-
       }
     });
   }
 }
 
 function isBeginningOfParenthesizedVariable(characters: string[]): boolean {
-  return characters.slice(-6).join("") !== "var(--" && characters.slice(-3).join("") === "(--";
+  return (
+    isBeginningOfArbitrarySyntax(characters, "(--") &&
+    !isBeginningOfArbitrarySyntax(characters, "[var(--")
+  );
+}
+
+function isBeginningOfArbitraryShorthand(characters: string[]): boolean {
+  return isBeginningOfArbitrarySyntax(characters, "[--");
 }
 
 function isBeginningOfArbitraryVariable(characters: string[]): boolean {
-  const toBe = "[var(--".split("");
+  return isBeginningOfArbitrarySyntax(characters, "[var(--");
+}
+
+function isBeginningOfArbitrarySyntax(characters: string[], syntax: string): boolean {
+  const toBe = syntax.split("");
 
   for(let i = characters.length - 1; i >= 0; i--){
 
@@ -182,7 +216,7 @@ function isBeginningOfArbitraryVariable(characters: string[]): boolean {
     }
 
     if(character !== expectedChar){
-      if(expectedChar === "[" && character === "_"){
+      if(character === "_"){
         continue;
       }
 


### PR DESCRIPTION
Now supports Tailwind CSS v3 shorthands.  

```tsx
// ❌ BAD: Incorrect css variable syntax with option `syntax: "shorthand"`
<div class="bg-[var(--primary)]" />;
```

```tsx
// ✅ GOOD: With option `syntax: "shorthand"` in Tailwind CSS v4
<div class="bg-(--primary)" />;
```

```tsx
// ✅ GOOD: With option `syntax: "shorthand"` in Tailwind CSS v3
<div class="bg-[--primary]" />;
```

```tsx
// ❌ BAD: Incorrect css variable syntax with option `syntax: "variable"` in Tailwind CSS v4
<div class="bg-(--primary)" />;
```

```tsx
// ❌ BAD: Incorrect css variable syntax with option `syntax: "variable"` in Tailwind CSS v3
<div class="bg-[--primary]" />;
```

```tsx
// ✅ GOOD: With option `syntax: "arbitrary"`
<div class="bg-[var(--primary)]" />;
```
