### PR TITLE
test: add no-unregistered-classes test for DaisyUI classes

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -17,6 +17,7 @@
     "clsx",
     "cnbuilder",
     "csstree",
+    "daisyui",
     "dcnb",
     "DCNB",
     "Declarators",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "astro-eslint-parser": "^1.2.2",
         "changelogen": "^0.6.2",
         "cspell": "^9.2.0",
+        "daisyui": "^5.0.50",
         "es-html-parser": "^0.3.0",
         "eslint": "^9.33.0",
         "eslint-plugin-better-tailwindcss": "file:./",
@@ -3778,6 +3779,16 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/daisyui": {
+      "version": "5.0.50",
+      "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.50.tgz",
+      "integrity": "sha512-c1PweK5RI1C76q58FKvbS4jzgyNJSP6CGTQ+KkZYzADdJoERnOxFoeLfDHmQgxLpjEzlYhFMXCeodQNLCC9bow==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "astro-eslint-parser": "^1.2.2",
     "changelogen": "^0.6.2",
     "cspell": "^9.2.0",
+    "daisyui": "^5.0.50",
     "es-html-parser": "^0.3.0",
     "eslint": "^9.33.0",
     "eslint-plugin-better-tailwindcss": "file:./",

--- a/src/rules/no-unregistered-classes.test.ts
+++ b/src/rules/no-unregistered-classes.test.ts
@@ -557,7 +557,7 @@ describe(noUnregisteredClasses.name, () => {
               "tailwind.css": css`
                 @import "tailwindcss";
 
-                @plugin 'daisyui';
+                @plugin "daisyui";
               `
             },
             options: [{

--- a/src/rules/no-unregistered-classes.test.ts
+++ b/src/rules/no-unregistered-classes.test.ts
@@ -514,11 +514,11 @@ describe(noUnregisteredClasses.name, () => {
       {
         valid: [
           {
-            angular: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
-            html: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
-            jsx: `() => <details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
-            svelte: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
-            vue: `<template><details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details></template>`,
+            angular: `<details class="dropdown-hover btn"></details>`,
+            html: `<details class="dropdown-hover btn"></details>`,
+            jsx: `() => <details class="dropdown-hover btn"></details>`,
+            svelte: `<details class="dropdown-hover btn"></details>`,
+            vue: `<template><details class="dropdown-hover btn"></details></template>`,
 
             files: {
               "tailwind.config.ts": ts`
@@ -545,14 +545,15 @@ describe(noUnregisteredClasses.name, () => {
       noUnregisteredClasses,
       TEST_SYNTAXES,
       {
-        valid: [
+        invalid: [
           {
-            angular: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
-            html: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
-            jsx: `() => <details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
-            svelte: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
-            vue: `<template><details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details></template>`,
+            angular: `<details class="dropdown-hover btn"></details>`,
+            html: `<details class="dropdown-hover btn"></details>`,
+            jsx: `() => <details class="dropdown-hover btn"></details>`,
+            svelte: `<details class="dropdown-hover btn"></details>`,
+            vue: `<template><details class="dropdown-hover btn"></details></template>`,
 
+            errors: 1,
             files: {
               "tailwind.css": css`
                 @import "tailwindcss";
@@ -561,8 +562,7 @@ describe(noUnregisteredClasses.name, () => {
               `
             },
             options: [{
-              entryPoint: "./tailwind.css",
-              ignore: ["dropdown-hover"]
+              entryPoint: "./tailwind.css"
             }]
           }
         ]

--- a/src/rules/no-unregistered-classes.test.ts
+++ b/src/rules/no-unregistered-classes.test.ts
@@ -561,8 +561,8 @@ describe(noUnregisteredClasses.name, () => {
               `
             },
             options: [{
-              entryPoint: "./tailwind.css"
-              // ignore: ["dropdown-hover"]
+              entryPoint: "./tailwind.css",
+              ignore: ["dropdown-hover"]
             }]
           }
         ]

--- a/src/rules/no-unregistered-classes.test.ts
+++ b/src/rules/no-unregistered-classes.test.ts
@@ -514,11 +514,11 @@ describe(noUnregisteredClasses.name, () => {
       {
         valid: [
           {
-            angular: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
-            html: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
-            jsx: `() => <div><div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div></div>`,
-            svelte: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
-            vue: `<template><div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div></template>`,
+            angular: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
+            html: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
+            jsx: `() => <details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
+            svelte: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
+            vue: `<template><details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details></template>`,
 
             files: {
               "tailwind.config.ts": ts`
@@ -547,11 +547,11 @@ describe(noUnregisteredClasses.name, () => {
       {
         valid: [
           {
-            angular: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
-            html: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
-            jsx: `() => <div><div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div></div>`,
-            svelte: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
-            vue: `<template><div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div></template>`,
+            angular: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
+            html: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
+            jsx: `() => <details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
+            svelte: `<details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details>`,
+            vue: `<template><details class="dropdown-hover dropdown"><summary><button class="btn btn-circle btn-ghost btn-primary btn-xl btn-active">open</button></summary><ul><li>a</li></ul></details></template>`,
 
             files: {
               "tailwind.css": css`
@@ -562,6 +562,7 @@ describe(noUnregisteredClasses.name, () => {
             },
             options: [{
               entryPoint: "./tailwind.css"
+              // ignore: ["dropdown-hover"]
             }]
           }
         ]

--- a/src/rules/no-unregistered-classes.test.ts
+++ b/src/rules/no-unregistered-classes.test.ts
@@ -507,6 +507,68 @@ describe(noUnregisteredClasses.name, () => {
     );
   });
 
+  it.runIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)("should not report on DaisyUI classes in tailwind <= 3", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
+            html: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
+            jsx: `() => <div><div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div></div>`,
+            svelte: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
+            vue: `<template><div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div></template>`,
+
+            files: {
+              "tailwind.config.ts": ts`
+                import daisyui from "daisyui";
+
+                export default {
+                  plugins: [
+                    daisyui
+                  ],
+                };
+              `
+            },
+            options: [{
+              tailwindConfig: "./tailwind.config.ts"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
+  it.runIf(getTailwindcssVersion().major >= TailwindcssVersion.V4)("should not report on DaisyUI classes in tailwind >= 4", () => {
+    lint(
+      noUnregisteredClasses,
+      TEST_SYNTAXES,
+      {
+        valid: [
+          {
+            angular: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
+            html: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
+            jsx: `() => <div><div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div></div>`,
+            svelte: `<div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div>`,
+            vue: `<template><div class="dropdown-hover dropdown"><label>title</label><ul><button class="btn btn-circle btn-ghost btn-primary">one</button></ul></div></template>`,
+
+            files: {
+              "tailwind.css": css`
+                @import "tailwindcss";
+
+                @plugin 'daisyui';
+              `
+            },
+            options: [{
+              entryPoint: "./tailwind.css"
+            }]
+          }
+        ]
+      }
+    );
+  });
+
   it("should not report on groups and peers", () => {
     lint(
       noUnregisteredClasses,


### PR DESCRIPTION
Add DaisyUI dev dependency.
Add V3 test covering `btn`, `btn-primary`, `btn-circle`, `btn-ghost`, `dropdown`, and `dropdown-hover`.
Add V4 test for the same.

Warning, V4 test is failing on `dropdown-hover`.

References: #179