### PR TITLE
fix: error in no-conflicting-classes when used in tailwindcss 3

### DIFF
--- a/src/tailwindcss/conflicting-classes.async.worker.v3.ts
+++ b/src/tailwindcss/conflicting-classes.async.worker.v3.ts
@@ -1,8 +1,8 @@
 import { runAsWorker } from "synckit";
 
-import type { GetConflictingClassesRequest } from "./conflicting-classes.js";
+import type { GetConflictingClassesRequest, GetConflictingClassesResponse } from "./conflicting-classes.js";
 
 
-runAsWorker(async (_: GetConflictingClassesRequest) => {
-  return {};
+runAsWorker(async (_: GetConflictingClassesRequest): Promise<GetConflictingClassesResponse> => {
+  return { conflictingClasses: {}, warnings: [] };
 });


### PR DESCRIPTION
fixes: #203 