### PR TITLE
Angular parser: prevent crash when objectContent is undefined in createLiteralByLiteralMapKey

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,8 +58,5 @@
   "search.exclude": {
     "lib": true
   },
-  "typescript.tsdk": "node_modules/typescript/lib",
-  "[typescript]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  }
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -58,5 +58,8 @@
   "search.exclude": {
     "lib": true
   },
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/src/parsers/angular.test.ts
+++ b/src/parsers/angular.test.ts
@@ -405,7 +405,7 @@ describe("angular", () => {
       it("should lint classes around expressions", () => {
         lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
-          // 1st pass of multi pass fix
+            // 1st pass of multi pass fix
             {
               angular: "<img [class]=\"`b a ${'d c'} f e`\" />",
               angularOutput: "<img [class]=\"`a b ${'d c'} e f`\" />",
@@ -474,6 +474,41 @@ describe("angular", () => {
         });
       });
 
+      it('should not crash on dynamic [class] expression (no literal)', () => {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
+          valid: [
+            {
+              // Dynamic computed class expression – previously could crash parser
+              // when parent.source was unavailable.
+              angular: `<icon [class]="styles.icon({ disabled: disabled })" />`
+            }
+          ]
+        });
+      });
+
+      it('should not crash on dynamic [ngClass] expression (no literal)', () => {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
+          valid: [
+            {
+              angular: `<icon [ngClass]="styles.icon({ disabled: disabled })" />`
+            }
+          ]
+        });
+      });
+
+      it('should continue handling literal map keys without crashing', () => {
+        lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
+          invalid: [
+            {
+              // Sanity check: object-literal keys are still parsed and reordered
+              angular: `<img [class]="{ 'b a': true, 'd c': false }" />`,
+              angularOutput: `<img [class]="{ 'a b': true, 'c d': false }" />`,
+              errors: 2,
+              options: [{ order: 'asc' }]
+            }
+          ]
+        });
+      });
     });
 
   });

--- a/src/parsers/angular.test.ts
+++ b/src/parsers/angular.test.ts
@@ -474,7 +474,7 @@ describe("angular", () => {
         });
       });
 
-      it('should not crash on dynamic [class] expression (no literal)', () => {
+      it("should not crash on dynamic [class] expression (no literal)", () => {
         lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           valid: [
             {
@@ -486,7 +486,7 @@ describe("angular", () => {
         });
       });
 
-      it('should not crash on dynamic [ngClass] expression (no literal)', () => {
+      it("should not crash on dynamic [ngClass] expression (no literal)", () => {
         lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           valid: [
             {
@@ -496,15 +496,16 @@ describe("angular", () => {
         });
       });
 
-      it('should continue handling literal map keys without crashing', () => {
+      it("should continue handling literal map keys without crashing", () => {
         lint(enforceConsistentClassOrder, TEST_SYNTAXES, {
           invalid: [
             {
               // Sanity check: object-literal keys are still parsed and reordered
               angular: `<img [class]="{ 'b a': true, 'd c': false }" />`,
               angularOutput: `<img [class]="{ 'a b': true, 'c d': false }" />`,
+
               errors: 2,
-              options: [{ order: 'asc' }]
+              options: [{ order: "asc" }]
             }
           ]
         });

--- a/src/parsers/angular.ts
+++ b/src/parsers/angular.ts
@@ -207,24 +207,38 @@ function getAngularMatcherFunctions(ctx: Rule.RuleContext, matchers: Matcher[]):
 
 function createLiteralByLiteralMapKey(ctx: Rule.RuleContext, key: LiteralMapKey): Literal[] {
   // @ts-expect-error - angular types are faulty
-  const literalMap = key.parent as LiteralMap;
+  const literalMap = key?.parent as LiteralMap | undefined;
   // @ts-expect-error - angular types are faulty
-  const objectContent = literalMap.parent.source;
-  const keyContent = key.key;
+  const objectContent = literalMap?.parent?.source;
+  const keyContent = key?.key;
 
+  // Bail out if we can't parse safely
+  if (!literalMap || !literalMap.sourceSpan || typeof objectContent !== 'string' || typeof keyContent !== 'string') {
+    return [];
+  }
+  
   let start = 0;
   let end = 0;
 
-  for(const value of literalMap.values){
-    const currentStart = objectContent.slice(start).indexOf(keyContent);
+  const values = (literalMap as any).values as Array<{ sourceSpan: { start: number; end: number } }> | undefined;
+
+  for (const value of values ?? []) {
+    if (!value?.sourceSpan) continue;
+
+    const sliced = objectContent.slice(start);
+    const currentStart = sliced.indexOf(keyContent);
+    if (currentStart === -1) {
+      // Key not found from this position; avoid negative/invalid ranges
+      return [];
+    }
     const currentEnd = currentStart + keyContent.length;
 
-    if(
-      literalMap.sourceSpan.start + currentStart >= value.sourceSpan.start &&
-      literalMap.sourceSpan.start + currentStart <= value.sourceSpan.end ||
-      literalMap.sourceSpan.start + currentEnd >= value.sourceSpan.start &&
-      literalMap.sourceSpan.start + currentEnd <= value.sourceSpan.end
-    ){
+    if (
+      (literalMap.sourceSpan.start + currentStart >= value.sourceSpan.start &&
+        literalMap.sourceSpan.start + currentStart <= value.sourceSpan.end) ||
+      (literalMap.sourceSpan.start + currentEnd >= value.sourceSpan.start &&
+        literalMap.sourceSpan.start + currentEnd <= value.sourceSpan.end)
+    ) {
       start += currentEnd;
       end += currentEnd;
       continue;
@@ -232,28 +246,30 @@ function createLiteralByLiteralMapKey(ctx: Rule.RuleContext, key: LiteralMapKey)
 
     start += currentStart - (key.quoted ? 1 : 0);
     end += currentEnd + (key.quoted ? 1 : 0);
-
     break;
   }
 
-  const raw = objectContent.slice(start, end);
+  const safeStart = Math.max(0, start);
+  const safeEnd = Math.max(safeStart, end);
+  const raw = objectContent.slice(safeStart, safeEnd);
+
   const quotes = getQuotes(raw);
   const whitespaces = getWhitespace(keyContent);
-  const range = [literalMap.sourceSpan.start + start, literalMap.sourceSpan.start + end] satisfies [number, number];
+  const range = [literalMap.sourceSpan.start + safeStart, literalMap.sourceSpan.start + safeEnd] satisfies [number, number];
   const loc = getLocByRange(ctx, range);
-  const line = ctx.sourceCode.lines[loc.start.line - 1];
+  const line = ctx.sourceCode.lines[loc.start.line - 1] ?? '';
   const indentation = getIndentation(line);
 
   return [{
-    ...quotes,
-    ...whitespaces,
-    content: keyContent,
-    indentation,
-    loc,
-    range,
-    raw,
-    supportsMultiline: false,
-    type: "StringLiteral"
+      ...quotes,
+      ...whitespaces,
+      content: keyContent,
+      indentation,
+      loc,
+      range,
+      raw,
+      supportsMultiline: false,
+      type: "StringLiteral"
   }];
 }
 

--- a/src/parsers/angular.ts
+++ b/src/parsers/angular.ts
@@ -213,32 +213,32 @@ function createLiteralByLiteralMapKey(ctx: Rule.RuleContext, key: LiteralMapKey)
   const keyContent = key?.key;
 
   // Bail out if we can't parse safely
-  if (!literalMap || !literalMap.sourceSpan || typeof objectContent !== 'string' || typeof keyContent !== 'string') {
+  if(!literalMap?.sourceSpan || typeof objectContent !== "string" || typeof keyContent !== "string"){
     return [];
   }
-  
+
   let start = 0;
   let end = 0;
 
-  const values = (literalMap as any).values as Array<{ sourceSpan: { start: number; end: number } }> | undefined;
+  const values = (literalMap as any).values as { sourceSpan: { end: number; start: number; }; }[] | undefined;
 
-  for (const value of values ?? []) {
-    if (!value?.sourceSpan) continue;
+  for(const value of values ?? []){
+    if(!value?.sourceSpan){continue;}
 
     const sliced = objectContent.slice(start);
     const currentStart = sliced.indexOf(keyContent);
-    if (currentStart === -1) {
+    if(currentStart === -1){
       // Key not found from this position; avoid negative/invalid ranges
       return [];
     }
     const currentEnd = currentStart + keyContent.length;
 
-    if (
-      (literalMap.sourceSpan.start + currentStart >= value.sourceSpan.start &&
-        literalMap.sourceSpan.start + currentStart <= value.sourceSpan.end) ||
-      (literalMap.sourceSpan.start + currentEnd >= value.sourceSpan.start &&
-        literalMap.sourceSpan.start + currentEnd <= value.sourceSpan.end)
-    ) {
+    if(
+      literalMap.sourceSpan.start + currentStart >= value.sourceSpan.start &&
+      literalMap.sourceSpan.start + currentStart <= value.sourceSpan.end ||
+      literalMap.sourceSpan.start + currentEnd >= value.sourceSpan.start &&
+      literalMap.sourceSpan.start + currentEnd <= value.sourceSpan.end
+    ){
       start += currentEnd;
       end += currentEnd;
       continue;
@@ -257,19 +257,19 @@ function createLiteralByLiteralMapKey(ctx: Rule.RuleContext, key: LiteralMapKey)
   const whitespaces = getWhitespace(keyContent);
   const range = [literalMap.sourceSpan.start + safeStart, literalMap.sourceSpan.start + safeEnd] satisfies [number, number];
   const loc = getLocByRange(ctx, range);
-  const line = ctx.sourceCode.lines[loc.start.line - 1] ?? '';
+  const line = ctx.sourceCode.lines[loc.start.line - 1] ?? "";
   const indentation = getIndentation(line);
 
   return [{
-      ...quotes,
-      ...whitespaces,
-      content: keyContent,
-      indentation,
-      loc,
-      range,
-      raw,
-      supportsMultiline: false,
-      type: "StringLiteral"
+    ...quotes,
+    ...whitespaces,
+    content: keyContent,
+    indentation,
+    loc,
+    range,
+    raw,
+    supportsMultiline: false,
+    type: "StringLiteral"
   }];
 }
 


### PR DESCRIPTION
**Summary**
Fixes a TypeError in the Angular parser where `objectContent` can be `undefined` and `.slice` is called unguarded.
Adds defensive checks and safe fallbacks in `createLiteralByLiteralMapKey` so the rule bails out gracefully instead of crashing.
No behavioral change for valid inputs; only prevents executor failure on edge AST shapes.

**Problem**
Running ESLint with eslint-plugin-better-tailwindcss on Angular templates can crash with:

TypeError: Cannot read properties of undefined (reading 'slice')
Rule: better-tailwindcss/enforce-consistent-class-order (also reproducible on other rules reading class strings)
Root location:

File: parser for Angular templates
Function: createLiteralByLiteralMapKey
Line (approx.): `const currentStart = objectContent.slice(start).indexOf(keyContent);`
In certain AST shapes produced by Angular’s template parser, `literalMap.parent.source` is not present, so `objectContent` is undefined.

**Minimal Repro**
Given an Angular component with an inline template:

```
@Component({
  selector: 'x-demo',
  template: `
    <span [class]="computeClasses()" [attr.aria-label]="label"></span>
  `
})
export class DemoComponent {}
```
Linting this file with a config that enables better-tailwindcss rules may crash with the TypeError above, depending on how the template AST is provided to the parser and which nodes are visited by the rule.

**Root Cause**
createLiteralByLiteralMapKey assumes literalMap.parent.source exists (string).
When it is missing, objectContent is undefined.
The code calls `objectContent.slice(...),` causing a crash before the rule can report or skip.

**Fix**
Add defensive guards around literalMap, objectContent, and keyContent.
When any of these are not available or indexOf returns -1, return an empty array (no literals) instead of crashing.
Keep existing logic and return shape for valid cases.
