### PR TITLE
fix: check for tailwindcss before running rules

### DIFF
--- a/src/async-utils/config.ts
+++ b/src/async-utils/config.ts
@@ -1,7 +1,7 @@
 import { withCache } from "./cache.js";
 import { findFileRecursive } from "./fs.js";
 import { resolveCss } from "./resolvers.js";
-import { TailwindcssVersion } from "./version.js";
+import { TailwindcssVersion } from "./tailwindcss.js";
 
 import type { Warning } from "../types/async.js";
 

--- a/src/async-utils/context.ts
+++ b/src/async-utils/context.ts
@@ -1,6 +1,6 @@
 import { getTailwindConfigPath } from "./config.js";
+import { getTailwindcssVersion } from "./tailwindcss.js";
 import { getTSConfigPath } from "./tsconfig.js";
-import { getTailwindcssVersion } from "./version.js";
 
 import type { Warning } from "../types/async.js";
 

--- a/src/rules/enforce-consistent-class-order.ts
+++ b/src/rules/enforce-consistent-class-order.ts
@@ -66,7 +66,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const enforceConsistentClassOrder: ESLintRule<Options> = {
   name: "enforce-consistent-class-order" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         category: "Stylistic Issues",

--- a/src/rules/enforce-consistent-important-position.test.ts
+++ b/src/rules/enforce-consistent-important-position.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "vitest";
 import { enforceConsistentImportantPosition } from "better-tailwindcss:rules/enforce-consistent-important-position.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { css, ts } from "better-tailwindcss:tests/utils/template.js";
-import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 describe(enforceConsistentImportantPosition.name, () => {

--- a/src/rules/enforce-consistent-important-position.ts
+++ b/src/rules/enforce-consistent-important-position.ts
@@ -18,8 +18,8 @@ import { buildClass } from "better-tailwindcss:utils/class.js";
 import { lintClasses } from "better-tailwindcss:utils/lint.js";
 import { getCommonOptions } from "better-tailwindcss:utils/options.js";
 import { createRuleListener } from "better-tailwindcss:utils/rule.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 import { augmentMessageWithWarnings, splitClasses } from "better-tailwindcss:utils/utils.js";
-import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
 
 import type { Rule } from "eslint";
 
@@ -61,7 +61,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const enforceConsistentImportantPosition: ESLintRule<Options> = {
   name: "enforce-consistent-important-position" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         description: "Enforce consistent important position for classes.",

--- a/src/rules/enforce-consistent-line-wrapping.test.ts
+++ b/src/rules/enforce-consistent-line-wrapping.test.ts
@@ -1,10 +1,10 @@
-import { getTailwindcssVersion, TailwindcssVersion } from "src/async-utils/version.js";
 import { describe, it } from "vitest";
 
 import { enforceConsistentLineWrapping } from "better-tailwindcss:rules/enforce-consistent-line-wrapping.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { css, dedent, ts } from "better-tailwindcss:tests/utils/template.js";
 import { MatcherType } from "better-tailwindcss:types/rule.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 describe(enforceConsistentLineWrapping.name, () => {

--- a/src/rules/enforce-consistent-line-wrapping.ts
+++ b/src/rules/enforce-consistent-line-wrapping.ts
@@ -75,7 +75,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const enforceConsistentLineWrapping: ESLintRule<Options> = {
   name: "enforce-consistent-line-wrapping" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         category: "Stylistic Issues",

--- a/src/rules/enforce-consistent-variable-syntax.test.ts
+++ b/src/rules/enforce-consistent-variable-syntax.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "vitest";
 import { enforceConsistentVariableSyntax } from "better-tailwindcss:rules/enforce-consistent-variable-syntax.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { dedent } from "better-tailwindcss:tests/utils/template.js";
-import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 describe(enforceConsistentVariableSyntax.name, () => {

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -15,8 +15,8 @@ import { buildClass } from "better-tailwindcss:utils/class.js";
 import { lintClasses } from "better-tailwindcss:utils/lint.js";
 import { getCommonOptions } from "better-tailwindcss:utils/options.js";
 import { createRuleListener } from "better-tailwindcss:utils/rule.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 import { splitClasses } from "better-tailwindcss:utils/utils.js";
-import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
 
 import type { Rule } from "eslint";
 
@@ -56,7 +56,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const enforceConsistentVariableSyntax: ESLintRule<Options> = {
   name: "enforce-consistent-variable-syntax" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         description: "Enforce consistent syntax for css variables.",

--- a/src/rules/enforce-shorthand-classes.test.ts
+++ b/src/rules/enforce-shorthand-classes.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "vitest";
 import { enforceShorthandClasses } from "better-tailwindcss:rules/enforce-shorthand-classes.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { css, ts } from "better-tailwindcss:tests/utils/template.js";
-import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 describe(enforceShorthandClasses.name, () => {

--- a/src/rules/enforce-shorthand-classes.ts
+++ b/src/rules/enforce-shorthand-classes.ts
@@ -62,7 +62,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const enforceShorthandClasses: ESLintRule<Options> = {
   name: "enforce-shorthand-classes" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         description: "Enforce shorthand class names instead of longhand class names.",

--- a/src/rules/no-conflicting-classes.test.ts
+++ b/src/rules/no-conflicting-classes.test.ts
@@ -1,8 +1,8 @@
-import { getTailwindcssVersion, TailwindcssVersion } from "src/async-utils/version.js";
 import { describe, it } from "vitest";
 
 import { noConflictingClasses } from "better-tailwindcss:rules/no-conflicting-classes.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 describe.skipIf(getTailwindcssVersion().major <= TailwindcssVersion.V3)(noConflictingClasses.name, () => {

--- a/src/rules/no-conflicting-classes.ts
+++ b/src/rules/no-conflicting-classes.ts
@@ -58,7 +58,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const noConflictingClasses: ESLintRule<Options> = {
   name: "no-conflicting-classes" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         description: "Disallow classes that produce conflicting styles.",

--- a/src/rules/no-deprecated-classes.test.ts
+++ b/src/rules/no-deprecated-classes.test.ts
@@ -3,7 +3,7 @@ import { describe, it } from "vitest";
 import { noDeprecatedClasses } from "better-tailwindcss:rules/no-deprecated-classes.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { css } from "better-tailwindcss:tests/utils/template.js";
-import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 const testCases = [

--- a/src/rules/no-deprecated-classes.ts
+++ b/src/rules/no-deprecated-classes.ts
@@ -18,8 +18,8 @@ import { buildClass } from "better-tailwindcss:utils/class.js";
 import { lintClasses } from "better-tailwindcss:utils/lint.js";
 import { getCommonOptions } from "better-tailwindcss:utils/options.js";
 import { createRuleListener } from "better-tailwindcss:utils/rule.js";
+import { getTailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 import { augmentMessageWithWarnings, replacePlaceholders, splitClasses } from "better-tailwindcss:utils/utils.js";
-import { getTailwindcssVersion } from "better-tailwindcss:utils/version.js";
 
 import type { Rule } from "eslint";
 
@@ -60,7 +60,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const noDeprecatedClasses: ESLintRule<Options> = {
   name: "no-deprecated-classes" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         description: "Disallow the use of deprecated Tailwind CSS classes.",

--- a/src/rules/no-duplicate-classes.ts
+++ b/src/rules/no-duplicate-classes.ts
@@ -48,7 +48,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const noDuplicateClasses: ESLintRule<Options> = {
   name: "no-duplicate-classes" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         category: "Stylistic Issues",

--- a/src/rules/no-restricted-classes.ts
+++ b/src/rules/no-restricted-classes.ts
@@ -56,7 +56,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const noRestrictedClasses: ESLintRule<Options> = {
   name: "no-restricted-classes" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         description: "Disallow restricted classes.",

--- a/src/rules/no-unnecessary-whitespace.ts
+++ b/src/rules/no-unnecessary-whitespace.ts
@@ -51,7 +51,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const noUnnecessaryWhitespace: ESLintRule<Options> = {
   name: "no-unnecessary-whitespace" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         category: "Stylistic Issues",

--- a/src/rules/no-unregistered-classes.test.ts
+++ b/src/rules/no-unregistered-classes.test.ts
@@ -1,9 +1,9 @@
-import { getTailwindcssVersion, TailwindcssVersion } from "src/async-utils/version.js";
 import { describe, it } from "vitest";
 
 import { noUnregisteredClasses } from "better-tailwindcss:rules/no-unregistered-classes.js";
 import { lint, TEST_SYNTAXES } from "better-tailwindcss:tests/utils/lint.js";
 import { css, ts } from "better-tailwindcss:tests/utils/template.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 describe(noUnregisteredClasses.name, () => {

--- a/src/rules/no-unregistered-classes.ts
+++ b/src/rules/no-unregistered-classes.ts
@@ -66,7 +66,7 @@ const DOCUMENTATION_URL = "https://github.com/schoero/eslint-plugin-better-tailw
 export const noUnregisteredClasses: ESLintRule<Options> = {
   name: "no-unregistered-classes" as const,
   rule: {
-    create: ctx => createRuleListener(ctx, getOptions(ctx), lintLiterals),
+    create: ctx => createRuleListener(ctx, getOptions, lintLiterals),
     meta: {
       docs: {
         description: "Disallow any css classes that are not registered in tailwindcss.",

--- a/src/tailwindcss/class-order.ts
+++ b/src/tailwindcss/class-order.ts
@@ -2,10 +2,10 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
-import { getTailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
-import type { Async, Warning } from "better-tailwindcss:types/async.js";
+import type { Warning } from "better-tailwindcss:types/async.js";
 
 
 export type ClassOrder = [className: string, order: bigint | null][];
@@ -19,9 +19,12 @@ export interface GetClassOrderRequest {
 
 export type GetClassOrderResponse = { classOrder: ClassOrder; warnings: (Warning | undefined)[]; };
 
-export const getClassOrder = createSyncFn<
-  Async<GetClassOrderRequest, GetClassOrderResponse>
->(getWorkerPath(), getWorkerOptions());
+export function getClassOrder(req: GetClassOrderRequest): GetClassOrderResponse {
+  const workerPath = getWorkerPath();
+  const workerOptions = getWorkerOptions();
+
+  return createSyncFn(workerPath, workerOptions)(req);
+}
 
 function getWorkerPath() {
   const { major } = getTailwindcssVersion();

--- a/src/tailwindcss/conflicting-classes.ts
+++ b/src/tailwindcss/conflicting-classes.ts
@@ -3,10 +3,10 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
-import { getTailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
-import type { Async, Warning } from "better-tailwindcss:types/async.js";
+import type { Warning } from "better-tailwindcss:types/async.js";
 
 
 export type ConflictingClasses = {
@@ -28,9 +28,12 @@ export interface GetConflictingClassesRequest {
 
 export type GetConflictingClassesResponse = { conflictingClasses: ConflictingClasses; warnings: (Warning | undefined)[]; };
 
-export const getConflictingClasses = createSyncFn<
-  Async<GetConflictingClassesRequest, GetConflictingClassesResponse>
->(getWorkerPath(), getWorkerOptions());
+export function getConflictingClasses(req: GetConflictingClassesRequest): GetConflictingClassesResponse {
+  const workerPath = getWorkerPath();
+  const workerOptions = getWorkerOptions();
+
+  return createSyncFn(workerPath, workerOptions)(req);
+}
 
 function getWorkerPath() {
   const { major } = getTailwindcssVersion();

--- a/src/tailwindcss/context.async.ts
+++ b/src/tailwindcss/context.async.ts
@@ -1,4 +1,4 @@
-import { getTailwindcssVersion, TailwindcssVersion } from "../async-utils/version.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "../async-utils/tailwindcss.js";
 import { createTailwindContext as createTailwindContextV3 } from "./context.async.v3.js";
 import { createTailwindContext as createTailwindContextV4 } from "./context.async.v4.js";
 

--- a/src/tailwindcss/custom-component-classes.ts
+++ b/src/tailwindcss/custom-component-classes.ts
@@ -7,7 +7,7 @@ import { createSyncFn } from "synckit";
 
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
-import type { Async, Warning } from "better-tailwindcss:types/async.js";
+import type { Warning } from "better-tailwindcss:types/async.js";
 
 
 export type CustomComponentClasses = string[];
@@ -20,9 +20,12 @@ export interface GetCustomComponentClassesRequest {
 
 export type GetCustomComponentClassesResponse = { customComponentClasses: CustomComponentClasses; warnings: (Warning | undefined)[]; };
 
-export const getCustomComponentClasses = createSyncFn<
-  Async<GetCustomComponentClassesRequest, GetCustomComponentClassesResponse>
->(getWorkerPath(), getWorkerOptions());
+export function getCustomComponentClasses(req: GetCustomComponentClassesRequest): GetCustomComponentClassesResponse {
+  const workerPath = getWorkerPath();
+  const workerOptions = getWorkerOptions();
+
+  return createSyncFn(workerPath, workerOptions)(req);
+}
 
 function getWorkerPath() {
   return resolve(getCurrentDirectory(), "./custom-component-classes.async.worker.js");

--- a/src/tailwindcss/dissect-classes.test.ts
+++ b/src/tailwindcss/dissect-classes.test.ts
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import { getDissectedClasses } from "better-tailwindcss:tailwindcss/dissect-classes.js";
 import { css } from "better-tailwindcss:tests/utils/template.js";
 import { createTestFile, resetTestingDirectory } from "better-tailwindcss:tests/utils/tmp.js";
-import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 function dissectClass(className: string) {

--- a/src/tailwindcss/dissect-classes.ts
+++ b/src/tailwindcss/dissect-classes.ts
@@ -2,10 +2,10 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
-import { getTailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
-import type { Async, Warning } from "better-tailwindcss:types/async.js";
+import type { Warning } from "better-tailwindcss:types/async.js";
 
 
 export interface GetDissectedClassRequest {
@@ -27,9 +27,12 @@ export interface DissectedClass {
 
 export type GetDissectedClassResponse = { dissectedClasses: DissectedClass[]; warnings: (Warning | undefined)[]; };
 
-export const getDissectedClasses = createSyncFn<
-  Async<GetDissectedClassRequest, GetDissectedClassResponse>
->(getWorkerPath(), getWorkerOptions());
+export function getDissectedClasses(req: GetDissectedClassRequest): GetDissectedClassResponse {
+  const workerPath = getWorkerPath();
+  const workerOptions = getWorkerOptions();
+
+  return createSyncFn(workerPath, workerOptions)(req);
+}
 
 function getWorkerPath() {
   const { major } = getTailwindcssVersion();

--- a/src/tailwindcss/prefix.ts
+++ b/src/tailwindcss/prefix.ts
@@ -2,10 +2,10 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
-import { getTailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
-import type { Async, Warning } from "better-tailwindcss:types/async.js";
+import type { Warning } from "better-tailwindcss:types/async.js";
 
 
 export type Prefix = string;
@@ -19,9 +19,12 @@ export interface GetPrefixRequest {
 
 export interface GetPrefixResponse { prefix: Prefix; suffix: Suffix; warnings: (Warning | undefined)[]; }
 
-export const getPrefix = createSyncFn<
-  Async<GetPrefixRequest, GetPrefixResponse>
->(getWorkerPath(), getWorkerOptions());
+export function getPrefix(req: GetPrefixRequest): GetPrefixResponse {
+  const workerPath = getWorkerPath();
+  const workerOptions = getWorkerOptions();
+
+  return createSyncFn(workerPath, workerOptions)(req);
+}
 
 function getWorkerPath() {
   const { major } = getTailwindcssVersion();

--- a/src/tailwindcss/unregistered-classes.ts
+++ b/src/tailwindcss/unregistered-classes.ts
@@ -2,10 +2,10 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
-import { getTailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
-import type { Async, Warning } from "better-tailwindcss:types/async.js";
+import type { Warning } from "better-tailwindcss:types/async.js";
 
 
 export type UnregisteredClass = string;
@@ -19,9 +19,12 @@ export interface GetUnregisteredClassesRequest {
 
 export type GetUnregisteredClassesResponse = { unregisteredClasses: UnregisteredClass[]; warnings: (Warning | undefined)[]; };
 
-export const getUnregisteredClasses = createSyncFn<
-  Async<GetUnregisteredClassesRequest, GetUnregisteredClassesResponse>
->(getWorkerPath(), getWorkerOptions());
+export function getUnregisteredClasses(req: GetUnregisteredClassesRequest): GetUnregisteredClassesResponse {
+  const workerPath = getWorkerPath();
+  const workerOptions = getWorkerOptions();
+
+  return createSyncFn(workerPath, workerOptions)(req);
+}
 
 function getWorkerPath() {
   const { major } = getTailwindcssVersion();

--- a/src/utils/class.ts
+++ b/src/utils/class.ts
@@ -1,4 +1,4 @@
-import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/version.js";
+import { getTailwindcssVersion, TailwindcssVersion } from "better-tailwindcss:utils/tailwindcss.js";
 
 
 interface ClassParts {

--- a/src/utils/options.ts
+++ b/src/utils/options.ts
@@ -5,11 +5,10 @@ import {
   DEFAULT_VARIABLE_NAMES
 } from "better-tailwindcss:options/default-options.js";
 import { isAttributesRegex, isCalleeRegex, isVariableRegex } from "better-tailwindcss:utils/matchers.js";
+import { warnOnce } from "better-tailwindcss:utils/warn.js";
 
 import type { Rule } from "eslint";
 
-
-let warningShown = false;
 
 export function getCommonOptions(ctx: Rule.RuleContext) {
 
@@ -21,14 +20,11 @@ export function getCommonOptions(ctx: Rule.RuleContext) {
   const tsconfig = getOption(ctx, "tsconfig");
 
   if(
-    !warningShown && (
-      Array.isArray(attributes) && attributes.some(attributes => isAttributesRegex(attributes)) ||
-      Array.isArray(callees) && callees.some(callees => isCalleeRegex(callees)) ||
-      Array.isArray(variables) && variables.some(variables => isVariableRegex(variables))
-    )
+    Array.isArray(attributes) && attributes.some(attributes => isAttributesRegex(attributes)) ||
+    Array.isArray(callees) && callees.some(callees => isCalleeRegex(callees)) ||
+    Array.isArray(variables) && variables.some(variables => isVariableRegex(variables))
   ){
-    console.warn("⚠️ Warning: Regex matching is deprecated and will be removed in the next major version. Please use matchers instead. See: https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/configuration/advanced.md#matchers");
-    warningShown = true;
+    warnOnce("Regex matching is deprecated and will be removed in the next major version. Please use matchers instead. See: https://github.com/schoero/eslint-plugin-better-tailwindcss/blob/main/docs/configuration/advanced.md#matchers");
   }
 
   return {

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -8,6 +8,8 @@ import { getAttributesByHTMLTag, getLiteralsByHTMLAttribute } from "better-tailw
 import { getAttributesByJSXElement, getLiteralsByJSXAttribute } from "better-tailwindcss:parsers/jsx.js";
 import { getAttributesBySvelteTag, getLiteralsBySvelteAttribute } from "better-tailwindcss:parsers/svelte.js";
 import { getAttributesByVueStartTag, getLiteralsByVueAttribute } from "better-tailwindcss:parsers/vue.js";
+import { isTailwindcssInstalled } from "better-tailwindcss:utils/tailwindcss.js";
+import { warnOnce } from "better-tailwindcss:utils/warn.js";
 
 import type { TmplAstElement } from "@angular-eslint/bundled-angular-compiler";
 import type { TagNode } from "es-html-parser";
@@ -27,8 +29,14 @@ export type Options =
   TagOption &
   VariableOption;
 
-export function createRuleListener(ctx: Rule.RuleContext, options: Options, lintLiterals: (ctx: Rule.RuleContext, literals: Literal[]) => void): Rule.RuleListener {
-  const { attributes, callees, tags, variables } = options;
+export function createRuleListener(ctx: Rule.RuleContext, getOptions: (ctx: Rule.RuleContext) => Options, lintLiterals: (ctx: Rule.RuleContext, literals: Literal[]) => void): Rule.RuleListener {
+
+  if(!isTailwindcssInstalled()){
+    warnOnce(`Tailwind CSS is not installed. Disabling rule ${ctx.id}.`);
+    return {};
+  }
+
+  const { attributes, callees, tags, variables } = getOptions(ctx);
 
   const callExpression = {
     CallExpression(node: Node) {

--- a/src/utils/warn.ts
+++ b/src/utils/warn.ts
@@ -1,0 +1,8 @@
+const warnedMessages = new Set<string>();
+
+export function warnOnce(message: string) {
+  if(!warnedMessages.has(message)){
+    console.warn("⚠️ Warning:", message);
+    warnedMessages.add(message);
+  }
+}


### PR DESCRIPTION
Checks if tailwindcss is installed before running rules. If tailwindcss is missing, the plugin will report a warning once.

fixes: #216 