### PR TITLE
fix: not detecting compoundVariants using slots from Tailwind Variants

### DIFF
--- a/src/options/callees/tv.ts
+++ b/src/options/callees/tv.ts
@@ -47,7 +47,7 @@ export const TV_COMPOUND_VARIANTS_CLASS = [
   [
     {
       match: MatcherType.ObjectValue,
-      pathPattern: "^compoundVariants\\[\\d+\\]\\.(?:className|class)$"
+      pathPattern: "^compoundVariants\\[\\d+\\]\\.(?:className|class).*$"
     }
   ]
 ] satisfies CalleeMatchers;
@@ -57,7 +57,7 @@ export const TV_COMPOUND_SLOTS_CLASS = [
   [
     {
       match: MatcherType.ObjectValue,
-      pathPattern: "^compoundSlots\\[\\d+\\]\\.(?:className|class)$"
+      pathPattern: "^compoundSlots\\[\\d+\\]\\.(?:className|class).*$"
     }
   ]
 ] satisfies CalleeMatchers;


### PR DESCRIPTION
When using Tailwind Variants `compoundVariants` that only apply to certain slots, the class string is not detected. 

In this example the className string in the compoundVariant for the `h1` slot is not linted. 

To reproduce, see this codesandbox https://codesandbox.io/p/devbox/h7kpvk and run `pnpm run lint --fix`

```
const tvClasses = tv({
  slots: {
    h1: `
      bg-red-500 font-bold
      hover:bg-blue-700
      active:font-bold
    `,
  },
  variants: {
    hasError: {
      true: "bg-green-500",
    },
    isSelected: {
      true: "border-yellow-500",
    },
    isWorking: {
      true: `
        bg-red-500 font-bold
        hover:bg-blue-100
        active:font-bold
      `,
    },
  },
  compoundVariants: [
    {
      isSelected: true,
      hasError: true,
      className: {
        h1: "bg-red-500 font-bold hover:bg-blue-100 active:font-bold",
      },
    },
  ],
});
```


The fix adds `.*` to the end of the compoundVariants and compoundSlots pathPattern to match all following object keys