### PR TITLE
Performance improvements

### DIFF
--- a/src/async-utils/cache.ts
+++ b/src/async-utils/cache.ts
@@ -1,5 +1,7 @@
 import { getModifiedDate } from "./fs.js";
 
+import type { AsyncContext } from "../utils/context.js";
+
 
 interface CacheItem {
   date: Date;
@@ -39,6 +41,22 @@ export function withCache<Result>(key: string, path: string | undefined, callbac
     CACHE.set(cacheKey, { date: new Date(), value });
     return value;
   }
+}
+
+/**
+ * Caches worker operation results.
+ *
+ * @template Operation The signature of the wrapped operation.
+ * @param name Unique name of the operation, used as part of the cache key.
+ * @param operation The operation to cache.
+ * @returns The wrapped operation.
+ */
+export function withOperationCache<Operation extends (ctx: AsyncContext, ...args: any[]) => any>(name: string, operation: Operation): Operation {
+  return ((ctx: AsyncContext, ...args: any[]) => withCache(
+    `${name}-${ctx.cwd}-${ctx.tsconfigPath}-${JSON.stringify(args)}`,
+    ctx.tailwindConfigPath,
+    () => operation(ctx, ...args)
+  )) as Operation;
 }
 
 export function clearCache() {

--- a/src/async-utils/cache.ts
+++ b/src/async-utils/cache.ts
@@ -9,7 +9,10 @@ interface CacheItem {
 const CACHE = new Map<string, CacheItem>();
 
 export function invalidateByModifiedDate(cache: CacheItem, path: string | undefined): boolean {
-  if(!path){ return true; }
+  // without a path there is no file to watch for staleness
+  // the entry stays cached until clearCache()
+  // this requires callers to encode everything the callback depends on in the key
+  if(!path){ return false; }
 
   const modified = getModifiedDate(path);
   return modified > cache.date;

--- a/src/async-utils/cache.ts
+++ b/src/async-utils/cache.ts
@@ -8,11 +8,57 @@ interface CacheItem {
   value: any;
 }
 
-const CACHE = new Map<string, CacheItem>();
+class LruCache {
+
+  private cache = new Map<string, CacheItem>();
+  private maxSize: number;
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  get(key: string): CacheItem | undefined {
+    const item = this.cache.get(key);
+
+    if(item){
+      // fresh access, move to the end
+      this.cache.delete(key);
+      this.cache.set(key, item);
+    }
+
+    return item;
+  }
+
+  set(key: string, item: CacheItem): void {
+    // fresh write, move to the end if present
+    this.cache.delete(key);
+    this.cache.set(key, item);
+
+    // size limit
+    if(this.cache.size > this.maxSize){
+      const oldestKey = this.cache.keys().next().value;
+
+      if(oldestKey !== undefined){
+        this.cache.delete(oldestKey);
+      }
+    }
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+}
+
+// operation results and resolved configs are few but potentially large
+const CACHE = new LruCache(1000);
+
+// per-class verdicts are booleans, but every distinct class name ever seen creates an entry
+const CLASS_CACHE = new LruCache(20_000);
 
 export function invalidateByModifiedDate(cache: CacheItem, path: string | undefined): boolean {
   // without a path there is no file to watch for staleness
-  // the entry stays cached until clearCache()
+  // the entry stays cached until clearCache() or lru eviction
   // this requires callers to encode everything the callback depends on in the key
   if(!path){ return false; }
 
@@ -80,7 +126,7 @@ export function withPerClassCache(key: string, path: string | undefined, classes
       continue;
     }
 
-    const cached = CACHE.get(`${key}-${className}-${path}`);
+    const cached = CLASS_CACHE.get(`${key}-${className}-${path}`);
 
     if(cached && !(modified && modified > cached.date)){
       verdicts.set(className, cached.value as boolean);
@@ -98,7 +144,7 @@ export function withPerClassCache(key: string, path: string | undefined, classes
       const value = matchedClasses.has(className);
 
       verdicts.set(className, value);
-      CACHE.set(`${key}-${className}-${path}`, { date, value });
+      CLASS_CACHE.set(`${key}-${className}-${path}`, { date, value });
     }
   }
 
@@ -107,4 +153,5 @@ export function withPerClassCache(key: string, path: string | undefined, classes
 
 export function clearCache() {
   CACHE.clear();
+  CLASS_CACHE.clear();
 }

--- a/src/async-utils/cache.ts
+++ b/src/async-utils/cache.ts
@@ -59,6 +59,52 @@ export function withOperationCache<Operation extends (ctx: AsyncContext, ...args
   )) as Operation;
 }
 
+/**
+ * Caches an operation that filters a class list per class.
+ *
+ * @param key Unique name of the operation, used as part of the cache key.
+ * @param path Path of the file to watch for changes.
+ * @param classes The classes to filter.
+ * @param filterClasses The operation, called with the classes that have no cached verdict yet.
+ * @returns The classes for which the operation's verdict is positive, in input order.
+ */
+export function withPerClassCache(key: string, path: string | undefined, classes: string[], filterClasses: (uncachedClasses: string[]) => string[]): string[] {
+  const modified = path ? getModifiedDate(path) : undefined;
+
+  const verdicts = new Map<string, boolean>();
+  const uncachedClasses: string[] = [];
+
+  for(const className of classes){
+
+    if(verdicts.has(className)){
+      continue;
+    }
+
+    const cached = CACHE.get(`${key}-${className}-${path}`);
+
+    if(cached && !(modified && modified > cached.date)){
+      verdicts.set(className, cached.value as boolean);
+    } else {
+      uncachedClasses.push(className);
+      verdicts.set(className, false);
+    }
+  }
+
+  if(uncachedClasses.length > 0){
+    const matchedClasses = new Set(filterClasses(uncachedClasses));
+    const date = new Date();
+
+    for(const className of uncachedClasses){
+      const value = matchedClasses.has(className);
+
+      verdicts.set(className, value);
+      CACHE.set(`${key}-${className}-${path}`, { date, value });
+    }
+  }
+
+  return classes.filter(className => verdicts.get(className));
+}
+
 export function clearCache() {
   CACHE.clear();
 }

--- a/src/async-utils/tsconfig.ts
+++ b/src/async-utils/tsconfig.ts
@@ -16,7 +16,7 @@ export interface GetTSConfigResponse {
   warnings: (Warning | undefined)[];
 }
 
-export const getTSConfigPath = ({ configPath, cwd }: GetTSConfigRequest): GetTSConfigResponse => withCache("tsconfig-path", configPath, () => {
+export const getTSConfigPath = ({ configPath, cwd }: GetTSConfigRequest): GetTSConfigResponse => withCache(`tsconfig-path-${cwd}`, configPath, () => {
 
   const potentialPaths = [
     ...configPath ? [configPath] : [],

--- a/src/rules/enforce-canonical-classes.ts
+++ b/src/rules/enforce-canonical-classes.ts
@@ -69,6 +69,8 @@ function lintLiterals(ctx: Context<typeof enforceCanonicalClasses>, literals: Li
   const { collapse, ignore, logical, rootFontSize } = ctx.options;
   const ignoredClassRegexes = ignore.map(ignoredClass => getCachedRegex(ignoredClass));
 
+  const asyncCtx = async(ctx);
+
   for(const literal of literals){
 
     const classes = splitClasses(literal.content);
@@ -80,7 +82,7 @@ function lintLiterals(ctx: Context<typeof enforceCanonicalClasses>, literals: Li
       continue;
     }
 
-    const { canonicalClasses, warnings } = getCanonicalClasses(async(ctx), filteredUniqueClasses, {
+    const { canonicalClasses, warnings } = getCanonicalClasses(asyncCtx, filteredUniqueClasses, {
       collapse,
       logicalToPhysical: logical,
       rem: rootFontSize

--- a/src/rules/enforce-consistent-class-order.ts
+++ b/src/rules/enforce-consistent-class-order.ts
@@ -14,6 +14,7 @@ import { display, splitClasses, splitWhitespaces } from "better-tailwindcss:util
 import type { DissectedClass } from "better-tailwindcss:tailwindcss/dissect-classes.js";
 import type { Warning } from "better-tailwindcss:types/async.js";
 import type { Context } from "better-tailwindcss:types/rule.js";
+import type { AsyncContext } from "better-tailwindcss:utils/context.js";
 
 
 export const enforceConsistentClassOrder = createRule({
@@ -100,6 +101,8 @@ export const enforceConsistentClassOrder = createRule({
 
     const { messageStyle } = ctx.options;
 
+    const asyncCtx = async(ctx);
+
     for(const literal of literals){
 
       const classChunks = splitClasses(literal.content);
@@ -122,7 +125,7 @@ export const enforceConsistentClassOrder = createRule({
         unsortableClasses[1] = classChunks.pop() ?? "";
       }
 
-      const [sortedClassChunks, warnings] = sortClassNames(ctx, classChunks);
+      const [sortedClassChunks, warnings] = sortClassNames(ctx, asyncCtx, classChunks);
 
       const classes: string[] = [];
 
@@ -167,7 +170,7 @@ export const enforceConsistentClassOrder = createRule({
 });
 
 
-function sortClassNames(ctx: Context<typeof enforceConsistentClassOrder>, classes: string[]): [classes: string[], warnings?: (Warning | undefined)[]] {
+function sortClassNames(ctx: Context<typeof enforceConsistentClassOrder>, asyncCtx: AsyncContext, classes: string[]): [classes: string[], warnings?: (Warning | undefined)[]] {
 
   const { componentClassOrder, componentClassPosition, order, unknownClassOrder, unknownClassPosition } = ctx.options;
 
@@ -183,10 +186,10 @@ function sortClassNames(ctx: Context<typeof enforceConsistentClassOrder>, classe
     return [classes];
   }
 
-  const { classOrder, warnings } = getClassOrder(async(ctx), classes);
+  const { classOrder, warnings } = getClassOrder(asyncCtx, classes);
   const { detectComponentClasses } = ctx.options;
   const customComponentClasses = detectComponentClasses
-    ? getCustomComponentClasses(async(ctx)).customComponentClasses
+    ? getCustomComponentClasses(asyncCtx).customComponentClasses
     : [];
 
   const officiallySortedClasses = classOrder
@@ -234,7 +237,7 @@ function sortClassNames(ctx: Context<typeof enforceConsistentClassOrder>, classe
     return [officiallySortedClasses, warnings];
   }
 
-  const { dissectedClasses } = getDissectedClasses(async(ctx), officiallySortedClasses);
+  const { dissectedClasses } = getDissectedClasses(asyncCtx, officiallySortedClasses);
 
   const variantMap: VariantMap = {};
 

--- a/src/rules/enforce-consistent-important-position.ts
+++ b/src/rules/enforce-consistent-important-position.ts
@@ -52,7 +52,9 @@ export const enforceConsistentImportantPosition = createRule({
 
       const classes = splitClasses(literal.content);
 
-      const { dissectedClasses, warnings } = getDissectedClasses(asyncCtx, classes);
+      const { dissectedClasses, warnings: dissectWarnings } = getDissectedClasses(asyncCtx, classes);
+
+      const warnings = [...dissectWarnings];
 
       lintClasses(ctx, literal, (className, index, after) => {
         const dissectedClass = dissectedClasses[className];

--- a/src/rules/enforce-consistent-important-position.ts
+++ b/src/rules/enforce-consistent-important-position.ts
@@ -46,11 +46,13 @@ export const enforceConsistentImportantPosition = createRule({
         : "legacy"
     );
 
+    const asyncCtx = async(ctx);
+
     for(const literal of literals){
 
       const classes = splitClasses(literal.content);
 
-      const { dissectedClasses, warnings } = getDissectedClasses(async(ctx), classes);
+      const { dissectedClasses, warnings } = getDissectedClasses(asyncCtx, classes);
 
       lintClasses(ctx, literal, (className, index, after) => {
         const dissectedClass = dissectedClasses[className];

--- a/src/rules/enforce-consistent-line-wrapping.ts
+++ b/src/rules/enforce-consistent-line-wrapping.ts
@@ -153,7 +153,9 @@ function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, litera
 
     const classes = splitClasses(literal.content);
 
-    const { dissectedClasses, warnings } = getDissectedClasses(asyncCtx, classes);
+    const { dissectedClasses, warnings: dissectWarnings } = getDissectedClasses(asyncCtx, classes);
+
+    const warnings = [...dissectWarnings];
 
     const invalidLineBreaks = isLineBreakStyleLikelyMisconfigured(ctx, literal.raw);
     const invalidIndentations = isIndentationLikelyMisconfigured(ctx, literal.raw);

--- a/src/rules/enforce-consistent-line-wrapping.ts
+++ b/src/rules/enforce-consistent-line-wrapping.ts
@@ -132,6 +132,8 @@ export const enforceConsistentLineWrapping = createRule({
 function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, literals: Literal[]) {
   const { classesPerLine, group: groupSeparator, messageStyle, preferSingleLine, printWidth, strictness, vueConvertToBinding } = ctx.options;
 
+  const asyncCtx = async(ctx);
+
   for(const literal of literals){
 
     if(!literal.supportsMultiline){
@@ -151,7 +153,7 @@ function lintLiterals(ctx: Context<typeof enforceConsistentLineWrapping>, litera
 
     const classes = splitClasses(literal.content);
 
-    const { dissectedClasses, warnings } = getDissectedClasses(async(ctx), classes);
+    const { dissectedClasses, warnings } = getDissectedClasses(asyncCtx, classes);
 
     const invalidLineBreaks = isLineBreakStyleLikelyMisconfigured(ctx, literal.raw);
     const invalidIndentations = isIndentationLikelyMisconfigured(ctx, literal.raw);

--- a/src/rules/enforce-consistent-variable-syntax.ts
+++ b/src/rules/enforce-consistent-variable-syntax.ts
@@ -49,10 +49,12 @@ function lintLiterals(ctx: Context<typeof enforceConsistentVariableSyntax>, lite
 
   const { syntax } = ctx.options;
 
+  const asyncCtx = async(ctx);
+
   for(const literal of literals){
     const classes = splitClasses(literal.content);
 
-    const { dissectedClasses, warnings } = getDissectedClasses(async(ctx), classes);
+    const { dissectedClasses, warnings } = getDissectedClasses(asyncCtx, classes);
 
     lintClasses(ctx, literal, className => {
       const dissectedClass = dissectedClasses[className];

--- a/src/rules/enforce-consistent-variant-order.ts
+++ b/src/rules/enforce-consistent-variant-order.ts
@@ -30,10 +30,12 @@ export const enforceConsistentVariantOrder = createRule({
       return;
     }
 
+    const asyncCtx = async(ctx);
+
     for(const literal of literals){
       const classes = splitClasses(literal.content);
-      const { dissectedClasses, warnings: dissectedWarnings } = getDissectedClasses(async(ctx), classes);
-      const { variantOrder, warnings } = getVariantOrder(async(ctx), classes);
+      const { dissectedClasses, warnings: dissectedWarnings } = getDissectedClasses(asyncCtx, classes);
+      const { variantOrder, warnings } = getVariantOrder(asyncCtx, classes);
       const allWarnings = [...dissectedWarnings, ...warnings];
 
       lintClasses(ctx, literal, className => {

--- a/src/rules/enforce-logical-properties.ts
+++ b/src/rules/enforce-logical-properties.ts
@@ -114,10 +114,12 @@ function lintLiterals(ctx: Context<typeof enforceLogicalProperties>, literals: L
   const { ignore } = ctx.options;
   const ignoredClassRegexes = ignore.map(ignoredClass => getCachedRegex(ignoredClass));
 
+  const asyncCtx = async(ctx);
+
   for(const literal of literals){
     const classes = splitClasses(literal.content);
 
-    const { dissectedClasses, warnings } = getDissectedClasses(async(ctx), classes);
+    const { dissectedClasses, warnings } = getDissectedClasses(asyncCtx, classes);
 
     const possibleFixes = Object.values(dissectedClasses).flatMap(dissectedClass => {
       const replacementBases = getReplacementBases(dissectedClass.base);
@@ -129,7 +131,7 @@ function lintLiterals(ctx: Context<typeof enforceLogicalProperties>, literals: L
       return replacementBases.map(base => buildClass(ctx, { ...dissectedClass, base }));
     });
 
-    const { unknownClasses } = getUnknownClasses(async(ctx), possibleFixes);
+    const { unknownClasses } = getUnknownClasses(asyncCtx, possibleFixes);
 
     lintClasses(ctx, literal, className => {
       if(ignoredClassRegexes.some(ignoredClassRegex => ignoredClassRegex.test(className))){

--- a/src/rules/enforce-shorthand-classes.ts
+++ b/src/rules/enforce-shorthand-classes.ts
@@ -124,15 +124,17 @@ export const shorthands = [
 
 
 function lintLiterals(ctx: Context<typeof enforceShorthandClasses>, literals: Literal[]) {
+  const asyncCtx = async(ctx);
+
   for(const literal of literals){
 
     const classes = splitClasses(literal.content);
-    const { dissectedClasses, warnings } = getDissectedClasses(async(ctx), classes);
+    const { dissectedClasses, warnings } = getDissectedClasses(asyncCtx, classes);
 
     const shorthandGroups = getShorthands(ctx, dissectedClasses);
 
     const { unknownClasses } = getUnknownClasses(
-      async(ctx),
+      asyncCtx,
       shorthandGroups
         .flat()
         .flatMap(([, shorthands]) => shorthands)

--- a/src/rules/no-conflicting-classes.ts
+++ b/src/rules/no-conflicting-classes.ts
@@ -32,11 +32,13 @@ export const noConflictingClasses = createRule({
 
 function lintLiterals(ctx: Context<typeof noConflictingClasses>, literals: Literal[]) {
 
+  const asyncCtx = async(ctx);
+
   for(const literal of literals){
 
     const classes = splitClasses(literal.content);
 
-    const { conflictingClasses, warnings } = getConflictingClasses(async(ctx), classes);
+    const { conflictingClasses, warnings } = getConflictingClasses(asyncCtx, classes);
 
     if(Object.keys(conflictingClasses).length === 0){
       continue;

--- a/src/rules/no-deprecated-classes.ts
+++ b/src/rules/no-deprecated-classes.ts
@@ -75,11 +75,13 @@ function lintLiterals(ctx: Context<typeof noDeprecatedClasses>, literals: Litera
 
   const { major, minor } = ctx.version;
 
+  const asyncCtx = async(ctx);
+
   for(const literal of literals){
 
     const classes = splitClasses(literal.content);
 
-    const { dissectedClasses, warnings } = getDissectedClasses(async(ctx), classes);
+    const { dissectedClasses, warnings } = getDissectedClasses(asyncCtx, classes);
 
     lintClasses(ctx, literal, className => {
       const dissectedClass = dissectedClasses[className];

--- a/src/rules/no-unknown-classes.ts
+++ b/src/rules/no-unknown-classes.ts
@@ -15,6 +15,7 @@ import { isConcatenatedClass, splitClasses } from "better-tailwindcss:utils/util
 
 import type { Literal } from "better-tailwindcss:types/ast.js";
 import type { Context } from "better-tailwindcss:types/rule.js";
+import type { AsyncContext } from "better-tailwindcss:utils/context.js";
 
 
 export const noUnknownClasses = createRule({
@@ -60,17 +61,18 @@ function lintLiterals(ctx: Context<typeof noUnknownClasses>, literals: Literal[]
 
   const { ignore } = ctx.options;
 
-  const { prefix, suffix } = getPrefix(async(ctx));
+  const asyncCtx = async(ctx);
+  const { prefix, suffix } = getPrefix(asyncCtx);
 
   const ignoredGroups = getCachedRegex(`^${escapeForRegex(`${prefix}${suffix}`)}group(?:\\/(\\S*))?$`);
   const ignoredPeers = getCachedRegex(`^${escapeForRegex(`${prefix}${suffix}`)}peer(?:\\/(\\S*))?$`);
 
-  const customComponentClassRegexes = getCustomComponentClassRegexes(ctx);
+  const customComponentClassRegexes = getCustomComponentClassRegexes(ctx, asyncCtx);
 
   for(const literal of literals){
     const classes = splitClasses(literal.content);
 
-    const { unknownClasses, warnings } = getUnknownClasses(async(ctx), classes);
+    const { unknownClasses, warnings } = getUnknownClasses(asyncCtx, classes);
 
     if(unknownClasses.length === 0){
       continue;
@@ -107,15 +109,15 @@ function lintLiterals(ctx: Context<typeof noUnknownClasses>, literals: Literal[]
   }
 }
 
-function getCustomComponentClassRegexes(ctx: Context<typeof noUnknownClasses>): RegExp[] | undefined {
+function getCustomComponentClassRegexes(ctx: Context<typeof noUnknownClasses>, asyncCtx: AsyncContext): RegExp[] | undefined {
   const { detectComponentClasses } = ctx.options;
 
   if(!detectComponentClasses){
     return;
   }
 
-  const { customComponentClasses } = getCustomComponentClasses(async(ctx));
-  const { prefix, suffix } = getPrefix(async(ctx));
+  const { customComponentClasses } = getCustomComponentClasses(asyncCtx);
+  const { prefix, suffix } = getPrefix(asyncCtx);
 
   return customComponentClasses.map(className => getCachedRegex(`^${escapeForRegex(`${prefix}${suffix}`)}(?:.*:)?${escapeForRegex(className)}$`));
 }

--- a/src/tailwindcss/canonical-classes.async.v4.ts
+++ b/src/tailwindcss/canonical-classes.async.v4.ts
@@ -16,15 +16,22 @@ export function getCanonicalClasses(tailwindContext: any, classes: string[], opt
     return result;
   }
 
+  type CanonicalizeCandidates = (candidates: string[], options: CanonicalClassOptions) => string[];
+
+  const canonicalizeCandidates: CanonicalizeCandidates = (candidates, candidateOptions) => tailwindContext.canonicalizeCandidates(candidates, candidateOptions);
+
   // tailwind currently crashes when unknown classes are passed to canonicalizeCandidates
   const unknownClasses = getUnknownClasses(tailwindContext, classes);
-  const knownClasses = classes.filter(className => !unknownClasses.includes(className));
+  const unknownClassSet = new Set(unknownClasses);
+  const knownClasses = classes.filter(className => !unknownClassSet.has(className));
 
-  const canonicalizedClasses = tailwindContext.canonicalizeCandidates?.(knownClasses, options);
+  const canonicalizedClasses = canonicalizeCandidates(knownClasses, options);
+  const canonicalizedClassSet = new Set(canonicalizedClasses);
+  const inputClassSet = new Set(classes);
 
-  const removedClasses = knownClasses.filter(className => !canonicalizedClasses.includes(className));
-  const originalClasses = knownClasses.filter(className => canonicalizedClasses.includes(className));
-  const canonicalClasses = canonicalizedClasses.filter(className => !classes.includes(className));
+  const removedClasses = knownClasses.filter(className => !canonicalizedClassSet.has(className));
+  const originalClasses = knownClasses.filter(className => canonicalizedClassSet.has(className));
+  const canonicalClasses = canonicalizedClasses.filter(className => !inputClassSet.has(className));
 
   for(const originalClass of originalClasses){
     result[originalClass] = {
@@ -44,15 +51,14 @@ export function getCanonicalClasses(tailwindContext: any, classes: string[], opt
     return result;
   }
 
+  const subsetCanonicalizations = removedClasses.map(removedClass => {
+    const subset = removedClasses.filter(className => className !== removedClass);
+
+    return new Set(canonicalizeCandidates(subset, options));
+  });
+
   for(const canonicalClass of canonicalClasses){
-    const necessaryClasses = removedClasses.filter(removedClass => {
-      const subset = removedClasses.filter(className => className !== removedClass);
-      const subsetCanonical = tailwindContext.canonicalizeCandidates(
-        subset,
-        options
-      );
-      return !subsetCanonical.includes(canonicalClass);
-    });
+    const necessaryClasses = removedClasses.filter((_, index) => !subsetCanonicalizations[index].has(canonicalClass));
 
     for(const originalClass of necessaryClasses){
       result[originalClass] = {

--- a/src/tailwindcss/canonical-classes.ts
+++ b/src/tailwindcss/canonical-classes.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
+import { withOperationCache } from "better-tailwindcss:utils/cache.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
 import type { Warning } from "better-tailwindcss:types/async.js";
@@ -34,7 +35,7 @@ export function createGetCanonicalClasses(ctx: Context): GetCanonicalClasses {
   const workerOptions = getWorkerOptions();
   const runWorker = createSyncFn(workerPath, workerOptions);
 
-  getCanonicalClasses = (ctx, classes, options) => runWorker("getCanonicalClasses", ctx, classes, options);
+  getCanonicalClasses = withOperationCache<GetCanonicalClasses>("getCanonicalClasses", (ctx, classes, options) => runWorker("getCanonicalClasses", ctx, classes, options));
 
   return getCanonicalClasses;
 }

--- a/src/tailwindcss/class-order.ts
+++ b/src/tailwindcss/class-order.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
+import { withOperationCache } from "better-tailwindcss:utils/cache.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
 import type { Warning } from "better-tailwindcss:types/async.js";
@@ -23,7 +24,7 @@ export function createGetClassOrder(ctx: Context): GetClassOrder {
   const workerOptions = getWorkerOptions();
   const runWorker = createSyncFn(workerPath, workerOptions);
 
-  getClassOrder = (ctx, classes) => runWorker("getClassOrder", ctx, classes);
+  getClassOrder = withOperationCache<GetClassOrder>("getClassOrder", (ctx, classes) => runWorker("getClassOrder", ctx, classes));
 
   return getClassOrder;
 }

--- a/src/tailwindcss/conflicting-classes.ts
+++ b/src/tailwindcss/conflicting-classes.ts
@@ -3,6 +3,7 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
+import { withOperationCache } from "better-tailwindcss:utils/cache.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
 import type { Warning } from "better-tailwindcss:types/async.js";
@@ -32,7 +33,7 @@ export function createGetConflictingClasses(ctx: Context): GetConflictingClasses
   const workerOptions = getWorkerOptions();
   const runWorker = createSyncFn(workerPath, workerOptions);
 
-  getConflictingClasses = (ctx, classes) => runWorker("getConflictingClasses", ctx, classes);
+  getConflictingClasses = withOperationCache<GetConflictingClasses>("getConflictingClasses", (ctx, classes) => runWorker("getConflictingClasses", ctx, classes));
 
   return getConflictingClasses;
 }

--- a/src/tailwindcss/dissect-classes.ts
+++ b/src/tailwindcss/dissect-classes.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
+import { withOperationCache } from "better-tailwindcss:utils/cache.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
 import type { Warning } from "better-tailwindcss:types/async.js";
@@ -36,7 +37,7 @@ export function createGetDissectedClasses(ctx: Context): GetDissectedClasses {
   const workerOptions = getWorkerOptions();
   const runWorker = createSyncFn(workerPath, workerOptions);
 
-  getDissectedClasses = (ctx, classes) => runWorker("getDissectedClasses", ctx, classes);
+  getDissectedClasses = withOperationCache<GetDissectedClasses>("getDissectedClasses", (ctx, classes) => runWorker("getDissectedClasses", ctx, classes));
 
   return getDissectedClasses;
 }

--- a/src/tailwindcss/unknown-classes.ts
+++ b/src/tailwindcss/unknown-classes.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
-import { withOperationCache } from "better-tailwindcss:utils/cache.js";
+import { withPerClassCache } from "better-tailwindcss:utils/cache.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
 import type { Warning } from "better-tailwindcss:types/async.js";
@@ -24,7 +24,12 @@ export function createGetUnknownClasses(ctx: Context): GetUnknownClasses {
   const workerOptions = getWorkerOptions();
   const runWorker = createSyncFn(workerPath, workerOptions);
 
-  getUnknownClasses = withOperationCache<GetUnknownClasses>("getUnknownClasses", (ctx, classes) => runWorker("getUnknownClasses", ctx, classes));
+  // whether a class is unknown does not depend on the rest of the list
+  // so it is more efficient than operation cache
+  getUnknownClasses = (ctx, classes) => ({
+    unknownClasses: withPerClassCache(`unknown-class-${ctx.cwd}-${ctx.tsconfigPath}`, ctx.tailwindConfigPath, classes, uncachedClasses => runWorker("getUnknownClasses", ctx, uncachedClasses).unknownClasses),
+    warnings: ctx.warnings
+  });
 
   return getUnknownClasses;
 }

--- a/src/tailwindcss/unknown-classes.ts
+++ b/src/tailwindcss/unknown-classes.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
+import { withOperationCache } from "better-tailwindcss:utils/cache.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
 import type { Warning } from "better-tailwindcss:types/async.js";
@@ -23,7 +24,7 @@ export function createGetUnknownClasses(ctx: Context): GetUnknownClasses {
   const workerOptions = getWorkerOptions();
   const runWorker = createSyncFn(workerPath, workerOptions);
 
-  getUnknownClasses = (ctx, classes) => runWorker("getUnknownClasses", ctx, classes);
+  getUnknownClasses = withOperationCache<GetUnknownClasses>("getUnknownClasses", (ctx, classes) => runWorker("getUnknownClasses", ctx, classes));
 
   return getUnknownClasses;
 }

--- a/src/tailwindcss/variant-order.ts
+++ b/src/tailwindcss/variant-order.ts
@@ -2,6 +2,7 @@ import { resolve } from "node:path";
 
 import { createSyncFn } from "synckit";
 
+import { withOperationCache } from "better-tailwindcss:utils/cache.js";
 import { getWorkerOptions } from "better-tailwindcss:utils/worker.js";
 
 import type { Warning } from "better-tailwindcss:types/async.js";
@@ -23,7 +24,7 @@ export function createGetVariantOrder(ctx: Context): GetVariantOrder {
   const workerOptions = getWorkerOptions();
   const runWorker = createSyncFn(workerPath, workerOptions);
 
-  getVariantOrder = (ctx, classes) => runWorker("getVariantOrder", ctx, classes);
+  getVariantOrder = withOperationCache<GetVariantOrder>("getVariantOrder", (ctx, classes) => runWorker("getVariantOrder", ctx, classes));
 
   return getVariantOrder;
 }

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -35,7 +35,7 @@ function getTSConfigPath({ configPath, cwd }: {
   configPath: string | undefined;
   cwd: string;
 }) {
-  return withCache("tsconfig-path", configPath, () => {
+  return withCache(`tsconfig-path-${cwd}`, configPath, () => {
     const potentialPaths = [
       ...configPath ? [configPath] : [],
       "tsconfig.json",
@@ -57,7 +57,7 @@ export function getTailwindConfigPath({ configPath, cwd, version }: {
   cwd: string;
   version: Version;
 }) {
-  return withCache("config-path", configPath, () => {
+  return withCache(`config-path-${cwd}`, configPath, () => {
     if(version.major >= 4){
 
       const foundConfigPath = configPath && findPathRecursive(cwd, cwd, [configPath]);

--- a/src/utils/rule.ts
+++ b/src/utils/rule.ts
@@ -26,6 +26,7 @@ import {
 import { getAttributesByVueStartTag, getLiteralsByVueAttribute } from "better-tailwindcss:parsers/vue.js";
 import { SelectorKind } from "better-tailwindcss:types/rule.js";
 import { getLocByRange } from "better-tailwindcss:utils/ast.js";
+import { withCache } from "better-tailwindcss:utils/cache.js";
 import { resolveJson } from "better-tailwindcss:utils/resolvers.js";
 import { augmentMessageWithWarnings, escapeMessage } from "better-tailwindcss:utils/utils.js";
 import { removeDefaults } from "better-tailwindcss:utils/valibot.js";
@@ -65,6 +66,23 @@ import type {
   VariableSelector
 } from "better-tailwindcss:types/rule.js";
 
+
+// caching tailwind's package.json so it scales better
+// the operation is called for every rule * every linted file
+const getTailwindPackage = (cwd: string) => withCache("tailwind-package", cwd, () => {
+  const packageJsonPath = resolveJson("tailwindcss/package.json", cwd);
+
+  if(!packageJsonPath){
+    return;
+  }
+
+  const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
+
+  return {
+    installation: dirname(packageJsonPath),
+    version: parseSemanticVersion(packageJson.version)
+  };
+});
 
 export function createRule<
   const Name extends string,
@@ -169,16 +187,14 @@ export function createRule<
           ? resolve(ctx.cwd, options.cwd)
           : ctx.cwd;
 
-        const packageJsonPath = resolveJson("tailwindcss/package.json", cwd);
+        const tailwindPackage = getTailwindPackage(cwd);
 
-        if(!packageJsonPath){
+        if(!tailwindPackage){
           warnOnce(`Tailwind CSS is not installed. Disabling rule ${ctx.id}.`);
           return {};
         }
 
-        const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf-8"));
-        const version = parseSemanticVersion(packageJson.version);
-        const installation = dirname(packageJsonPath);
+        const { installation, version } = tailwindPackage;
 
         const context = {
           cwd,

--- a/tests/utils/lint.ts
+++ b/tests/utils/lint.ts
@@ -110,7 +110,7 @@ export function lint<const Rule extends ESLintRule>(
 
     using _ = new TestDirectory(invalid.files);
 
-    for(const { RuleTester, syntaxes } of Object.values(LINTERS)){
+    for(const [linterName, { RuleTester, syntaxes }] of Object.entries(LINTERS)){
       for(const [name, options] of Object.entries(syntaxes)){
 
         const ruleTester = new RuleTester(options) as ESLintRuleTester;
@@ -125,7 +125,8 @@ export function lint<const Rule extends ESLintRule>(
             errors: invalid.errors,
             options: invalid.options ?? [],
             output: invalid[`${name}Output`] ?? null,
-            settings: invalid.settings ?? {}
+            settings: invalid.settings ?? {},
+            ...linterName === "oxlint" && { cwd: process.cwd() }
           }],
           valid: []
         });
@@ -139,7 +140,7 @@ export function lint<const Rule extends ESLintRule>(
 
     using _ = new TestDirectory(valid.files);
 
-    for(const { RuleTester, syntaxes } of Object.values(LINTERS)){
+    for(const [linterName, { RuleTester, syntaxes }] of Object.entries(LINTERS)){
       for(const [name, options] of Object.entries(syntaxes)){
 
         const ruleTester = new RuleTester(options) as ESLintRuleTester;
@@ -153,7 +154,8 @@ export function lint<const Rule extends ESLintRule>(
           valid: [{
             code: valid[name],
             options: valid.options ?? [],
-            settings: valid.settings ?? {}
+            settings: valid.settings ?? {},
+            ...linterName === "oxlint" && { cwd: process.cwd() }
           }]
         });
       }


### PR DESCRIPTION
Hi @schoero 

first of all many thanks for your work and time you invest into this project!

## Problem

I have heavy projects where the plugin performance degrades. The overall timings are comparable with famous [ts no-deprecated](https://typescript-eslint.io/rules/no-deprecated/) rule, sometimes even more, and take 30-40% of the whole linting time.

## Solution

Lint runs spent most of their time asking Tailwind the same questions over and over — for every rule and every file, the plugin re-resolved the Tailwind setup and sent identical class lists to the worker. This adds caching so each question is only answered once.

**Changes**

- Resolve the Tailwind package and build the async context once, instead of for every file and every class literal.
- Cache worker results (class order, unknown classes, canonical classes, etc.), invalidated when the Tailwind config changes.
- For unknown classes, cache the results per class instead of per list — only classes we haven't seen yet go to the worker.
- Skip repeated work when canonicalizing classes.
- All caches are LRU-bounded, so memory stays flat even in long-running editor sessions.
- Fix two cache-key bugs found along the way: config paths could collide between different working directories, and entries without a file to watch were treated as always stale instead of cacheable.

## Side note

There is one more PR on Tailwind side https://github.com/tailwindlabs/tailwindcss/pull/20427 with additional improvements (see the test section)

## Test

Tested at https://github.com/smnbbrv/better-tailwindcss-bench . The relevant part is the `epbt-patched / tw-now`

**plugin cost** (ms, cold run net of parse baseline)

| codebase   | epbt-now / tw-now | epbt-patched / tw-now | epbt-now / tw-patched | epbt-patched / tw-patched |
| ---------- | ----------------: | --------------------: | --------------------: | ------------------------: |
| mixed      |              6292 |           3965 (-37%) |           5395 (-14%) |               3595 (-43%) |
| repetitive |              5279 |           2425 (-54%) |            4819 (-9%) |               2124 (-60%) |
| unique     |              6096 |           5458 (-10%) |           5507 (-10%) |               5295 (-13%) |